### PR TITLE
fix: properly reverse outpoints list in confirmation cache

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -200,7 +200,11 @@ impl KaspaProvider {
 
         self.queue.push(ConfirmationFXG::from_msgs_outpoints(
             fxg.ids(),
-            vec![prev_outpoint.clone(), next_outpoint.clone()], // TODO: fix
+            vec![
+                prev_outpoint.clone(),
+                // TODO: it also needs to include any outpoints in-between
+                next_outpoint.clone(),
+            ],
         ));
         info!("Kaspa provider, added to progress indication work queue");
 


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
