### PR TITLE
Use finality measure based on REST API accepting block blue score and virtual blue score

### DIFF
--- a/dymension/libs/kaspa/demo/relayer/src/x/deposit.rs
+++ b/dymension/libs/kaspa/demo/relayer/src/x/deposit.rs
@@ -195,10 +195,16 @@ pub async fn demo(args: DemoArgs) -> Result<(), Box<dyn Error>> {
     let deposit_cache = DepositCache::new();
     let address = escrow_address.clone();
 
+    let client_clone = client.clone();
     let handle: JoinHandle<Deposit> = tokio::spawn(async move {
-        return deposit_loop(&deposit_cache, &client, address.address_to_string(), tx_id)
-            .await
-            .expect("deposit loop");
+        return deposit_loop(
+            &deposit_cache,
+            &client_clone,
+            address.address_to_string(),
+            tx_id,
+        )
+        .await
+        .expect("deposit loop");
     });
 
     let result: Deposit = handle.await?;
@@ -219,8 +225,15 @@ pub async fn demo(args: DemoArgs) -> Result<(), Box<dyn Error>> {
     );
 
     // validate deposit using kaspa rpc (validator operation)
-    let validation_result =
-        validate_new_deposit_inner(&w.api(), &deposit_recv, &w.net, &escrow_address, true).await?;
+    let validation_result = validate_new_deposit_inner(
+        &w.api(),
+        &client.client,
+        &deposit_recv,
+        &w.net,
+        &escrow_address,
+        true,
+    )
+    .await?;
 
     if validation_result {
         println!("Deposit validated");

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -18,6 +18,7 @@ use api_rs::apis::kaspa_addresses_api::{
     get_full_transactions_for_address_page_addresses_kaspa_address_full_transactions_page_get as transactions_page,
     GetFullTransactionsForAddressPageAddressesKaspaAddressFullTransactionsPageGetParams as args,
 };
+use api_rs::apis::kaspa_network_info_api::health_state_info_health_get as get_health;
 use api_rs::apis::kaspa_transactions_api::{
     get_transaction_transactions_transaction_id_get as get_tx_by_id,
     GetTransactionTransactionsTransactionIdGetParams as get_tx_by_id_params,
@@ -195,6 +196,38 @@ impl HttpClient {
         )
         .await?;
         Ok(tx)
+    }
+
+    pub async fn get_tx_by_id_slim(
+        &self,
+        tx_id: &str,
+        block_hash_hint: Option<String>,
+    ) -> Result<TxModel> {
+        info!("Querying kaspa tx by id slim: {:?}", tx_id);
+        let c = self.get_config();
+
+        let tx = get_tx_by_id(
+            &c,
+            get_tx_by_id_params {
+                transaction_id: tx_id.to_string(),
+                block_hash: block_hash_hint,
+                inputs: Some(false),
+                outputs: Some(false),
+                resolve_previous_outpoints: Some("no".to_string()),
+            },
+        )
+        .await?;
+        Ok(tx)
+    }
+
+    pub async fn get_blue_score(&self) -> Result<i64> {
+        let c = self.get_config();
+        let res = get_health(&c).await?;
+        let blue_score = res
+            .database
+            .blue_score
+            .ok_or(eyre::eyre!("Blue score is missing"))?;
+        Ok(blue_score)
     }
 }
 

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -38,12 +38,13 @@ pub fn is_mature(daa_score_block: u64, daa_score_virtual: u64, network_id: Netwo
 }
 
 /// returns true if accepted and final (reorg with very low probability)
-pub async fn is_final(
+/// NOTE: not using 'maturity' because don't want to confuse with the less safe maturity concept used by wallets
+pub async fn is_safe_against_reorg(
     rest_client: &HttpClient,
     tx_id: &str,
     block_hash_hint: Option<String>, // enables faster lookup
 ) -> Result<bool> {
-    is_final_n_confirmations(
+    is_safe_against_reorg_n_confs(
         rest_client,
         REQUIRED_FINALITY_BLUE_SCORE_CONFIRMATIONS,
         tx_id,
@@ -52,13 +53,12 @@ pub async fn is_final(
     .await
 }
 
-pub async fn is_final_n_confirmations(
+pub async fn is_safe_against_reorg_n_confs(
     rest_client: &HttpClient,
     required_confirmations: i64,
     tx_id: &str,
     containing_block_hash_hint: Option<String>, // enables faster lookup
 ) -> Result<bool> {
-
     // Note: we use the blue score from the rest client rather than querying against our own WPRC node because
     // the rest server anyway delegates this call to its own WRPC node
     // we want a consistent view of the network across both the TX query and the virtual blue score query

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -1,5 +1,6 @@
 use crate::api::client::HttpClient;
 use eyre::Result;
+use hardcode::tx::REQUIRED_FINALITY_BLUE_SCORE_CONFIRMATIONS;
 use kaspa_consensus_core::network::NetworkId;
 use kaspa_rpc_core::RpcHash;
 use kaspa_wallet_core::prelude::DynRpcApi;
@@ -39,12 +40,28 @@ pub fn is_mature(daa_score_block: u64, daa_score_virtual: u64, network_id: Netwo
 /// returns true if accepted and final (reorg with low probability)
 pub async fn is_final(
     rest_client: &HttpClient,
+    tx_id: &str,
+    block_hash_hint: Option<String>, // enables faster lookup
+) -> Result<bool> {
+    is_final_n_confirmations(
+        rest_client,
+        REQUIRED_FINALITY_BLUE_SCORE_CONFIRMATIONS,
+        tx_id,
+        block_hash_hint,
+    )
+    .await
+}
+
+pub async fn is_final_n_confirmations(
+    rest_client: &HttpClient,
     required_confirmations: i64,
     tx_id: &str,
     block_hash_hint: Option<String>, // enables faster lookup
 ) -> Result<bool> {
     let virtual_blue_score = rest_client.get_blue_score().await?;
-    let tx = rest_client.get_tx_by_id_slim(tx_id, block_hash_hint).await?;
+    let tx = rest_client
+        .get_tx_by_id_slim(tx_id, block_hash_hint)
+        .await?;
     let accepting_blue_score = tx
         .accepting_block_blue_score
         .ok_or(eyre::eyre!("Accepting block blue score is missing"))?;

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -38,16 +38,15 @@ pub fn is_mature(daa_score_block: u64, daa_score_virtual: u64, network_id: Netwo
 
 /// returns true if accepted and final (reorg with low probability)
 pub async fn is_final(
-    wrpc_client: &Arc<DynRpcApi>,
     rest_client: &HttpClient,
+    required_confirmations: i64,
     tx_id: &str,
+    block_hash_hint: Option<String>, // enables faster lookup
 ) -> Result<bool> {
-    let tx = rest_client.get_tx_by_id(tx_id).await?;
-    let accepting = tx
-        .accepting_block_hash
-        .ok_or(eyre::eyre!("Accepting block hash is missing"))?;
+    let virtual_blue_score = rest_client.get_blue_score().await?;
+    let tx = rest_client.get_tx_by_id_slim(tx_id, block_hash_hint).await?;
     let accepting_blue_score = tx
         .accepting_block_blue_score
         .ok_or(eyre::eyre!("Accepting block blue score is missing"))?;
-    Ok(true)
+    Ok(accepting_blue_score + required_confirmations <= virtual_blue_score)
 }

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -1,5 +1,4 @@
-/// Refactored copy
-/// https://github.com/kaspanet/rusty-kaspa/blob/v1.0.0/wallet/core/src/storage/transaction/record.rs
+use crate::api::client::HttpClient;
 use eyre::Result;
 use kaspa_consensus_core::network::NetworkId;
 use kaspa_rpc_core::RpcHash;
@@ -31,7 +30,24 @@ pub async fn is_tx_final(
 /// is reorged.
 /// Unsuitable for doing off-chain work such as minting on a bridge.
 pub fn is_mature(daa_score_block: u64, daa_score_virtual: u64, network_id: NetworkId) -> bool {
+    //  see https://github.com/kaspanet/rusty-kaspa/blob/v1.0.0/wallet/core/src/storage/transaction/record.rs
     let params = NetworkParams::from(network_id);
     let maturity = params.user_transaction_maturity_period_daa();
     daa_score_virtual >= daa_score_block + maturity
+}
+
+/// returns true if accepted and final (reorg with low probability)
+pub async fn is_final(
+    wrpc_client: &Arc<DynRpcApi>,
+    rest_client: &HttpClient,
+    tx_id: &str,
+) -> Result<bool> {
+    let tx = rest_client.get_tx_by_id(tx_id).await?;
+    let accepting = tx
+        .accepting_block_hash
+        .ok_or(eyre::eyre!("Accepting block hash is missing"))?;
+    let accepting_blue_score = tx
+        .accepting_block_blue_score
+        .ok_or(eyre::eyre!("Accepting block blue score is missing"))?;
+    Ok(true)
 }

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -37,7 +37,7 @@ pub fn is_mature(daa_score_block: u64, daa_score_virtual: u64, network_id: Netwo
     daa_score_virtual >= daa_score_block + maturity
 }
 
-/// returns true if accepted and final (reorg with low probability)
+/// returns true if accepted and final (reorg with very low probability)
 pub async fn is_final(
     rest_client: &HttpClient,
     tx_id: &str,
@@ -56,11 +56,15 @@ pub async fn is_final_n_confirmations(
     rest_client: &HttpClient,
     required_confirmations: i64,
     tx_id: &str,
-    block_hash_hint: Option<String>, // enables faster lookup
+    containing_block_hash_hint: Option<String>, // enables faster lookup
 ) -> Result<bool> {
+
+    // Note: we use the blue score from the rest client rather than querying against our own WPRC node because
+    // the rest server anyway delegates this call to its own WRPC node
+    // we want a consistent view of the network across both the TX query and the virtual blue score query
     let virtual_blue_score = rest_client.get_blue_score().await?;
     let tx = rest_client
-        .get_tx_by_id_slim(tx_id, block_hash_hint)
+        .get_tx_by_id_slim(tx_id, containing_block_hash_hint)
         .await?;
     let accepting_blue_score = tx
         .accepting_block_blue_score

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -7,25 +7,6 @@ use kaspa_wallet_core::prelude::DynRpcApi;
 use kaspa_wallet_core::utxo::NetworkParams;
 use std::sync::Arc;
 
-// TODO: needs a rework/rename
-pub async fn is_tx_final(
-    client: &Arc<DynRpcApi>,
-    block_hash: RpcHash,
-    network_id: NetworkId,
-) -> Result<bool> {
-    let block = client.get_block(block_hash, true).await?;
-    let dag_info = client
-        .get_block_dag_info()
-        .await
-        .map_err(|e| eyre::eyre!("Get block DAG info: {}", e))?;
-
-    Ok(is_mature(
-        block.header.daa_score,
-        dag_info.virtual_daa_score,
-        network_id,
-    ))
-}
-
 /// Returns true if the block is unlikely to be reorged
 /// Suitable only for sending transactions to Kaspa: the tranaction will fail if any input
 /// is reorged.

--- a/dymension/libs/kaspa/lib/core/src/finality/finality.rs
+++ b/dymension/libs/kaspa/lib/core/src/finality/finality.rs
@@ -7,27 +7,20 @@ use kaspa_wallet_core::prelude::DynRpcApi;
 use kaspa_wallet_core::utxo::NetworkParams;
 use std::sync::Arc;
 
-pub async fn validate_maturity_block(
+// TODO: needs a rework/rename
+pub async fn is_tx_final(
     client: &Arc<DynRpcApi>,
     block_hash: RpcHash,
     network_id: NetworkId,
 ) -> Result<bool> {
     let block = client.get_block(block_hash, true).await?;
-    validate_maturity(client, block.header.daa_score, network_id).await
-}
-
-pub async fn validate_maturity(
-    client: &Arc<DynRpcApi>,
-    block_daa_score: u64,
-    network_id: NetworkId,
-) -> Result<bool> {
     let dag_info = client
         .get_block_dag_info()
         .await
         .map_err(|e| eyre::eyre!("Get block DAG info: {}", e))?;
 
     Ok(is_mature(
-        block_daa_score,
+        block.header.daa_score,
         dag_info.virtual_daa_score,
         network_id,
     ))
@@ -37,8 +30,8 @@ pub async fn validate_maturity(
 /// Suitable only for sending transactions to Kaspa: the tranaction will fail if any input
 /// is reorged.
 /// Unsuitable for doing off-chain work such as minting on a bridge.
-pub fn is_mature(block_daa_score: u64, current_daa_score: u64, network_id: NetworkId) -> bool {
+pub fn is_mature(daa_score_block: u64, daa_score_virtual: u64, network_id: NetworkId) -> bool {
     let params = NetworkParams::from(network_id);
     let maturity = params.user_transaction_maturity_period_daa();
-    current_daa_score >= block_daa_score + maturity
+    daa_score_virtual >= daa_score_block + maturity
 }

--- a/dymension/libs/kaspa/lib/hardcode/src/tx.rs
+++ b/dymension/libs/kaspa/lib/hardcode/src/tx.rs
@@ -1,2 +1,35 @@
 pub const DUST_AMOUNT: u64 = 20_000_001;
 pub const RELAYER_FEE: u64 = 20_000; // HARDCODED: empirically saw at least 10500 needed TODO: dynamic
+
+/*
+In Kaspa, every node has a different and eventually converging view of the network.
+Nodes run a local algorithm where they connect gossiped blocks in a DAG. The DAG has a set of blue blocks and a set of red blocks.
+A TX can be contained in one or more blocks, but will not take effect on the state machine unless it is contained in a blue block, or
+it's contained in a red block which is an ancestor of a blue block. Such a blue block is called the accepting block.
+
+A TX can appear to be accepted on a node but may be reorged if the node's view of the network changes. This can happen if a different
+fork becomes heavier (has more blue blocks in its DAG). Therefore the way to ensure a low probability of reorg is to ensure that
+- the accepting block is an ancestor of the current DAG 'tip' (where tip is a virtual block connected to all dangling blue blocks)
+- the tip has a sufficiently higher blue score than the accepting block
+
+The REST API takes care of maintaining an up to date view of the network. It can tell us the blue score of the accepting block of a TX
+as well as the current blue score of the tip. We numerically compare these to determine if the TX is final, where final means will
+reorg with an acceptably low probability.
+
+
+Probabilities:
+- The numbers here are a combination of GPT and advice from discord, the true numbers can be derived from network parameters (K=124)
+- Kucoin centralized exchange uses 1000 confirmations for Kaspa deposits (source Discord)
+- 100-200 confirmations is suitable (source Discord)
+
+
+Blue Score Difference (d)	Time Elapsed (Approx)	Upper Bound on Reorg Probability (vs 33% attacker)	Security Level
+10	                          1 second	             < 56%	                                            Very Low
+100	                          10 seconds	         < 0.31%	                                        Low (Comparable to 1-2 Bitcoin confirmations)
+200	                          20 seconds	         < 0.00095% (9.5 x 10^-6)	                        Moderate (Comparable to 6 Bitcoin confirmations)
+1,000	                      ~1.7 minutes	         < 8.8 x 10^-26	                                    Extremely High (Far exceeds typical blockchain finality)
+6,000	                      10 minutes	         < 2.8 x 10^-151	                                Effectively Absolute / Cryptographically Final
+
+We choose 1000, which is probably over conservative.
+ */
+pub const REQUIRED_FINALITY_BLUE_SCORE_CONFIRMATIONS: i64 = 1000;

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
@@ -334,7 +334,7 @@ async fn get_utxo_to_spend(
         .await
         .map_err(|e| eyre::eyre!("Get escrow UTXOs: {}", e))?;
 
-    let block = kaspa_rpc
+    let b = kaspa_rpc
         .get_block_dag_info()
         .await
         .map_err(|e| eyre::eyre!("Get block DAG info: {}", e))?;
@@ -344,7 +344,7 @@ async fn get_utxo_to_spend(
     utxos.retain(|u| {
         finality::is_mature(
             u.utxo_entry.block_daa_score,
-            block.virtual_daa_score,
+            b.virtual_daa_score,
             network_id,
         )
     });

--- a/dymension/libs/kaspa/lib/validator/src/confirmation.rs
+++ b/dymension/libs/kaspa/lib/validator/src/confirmation.rs
@@ -130,8 +130,8 @@ pub async fn validate_confirmed_withdrawals(
                 }
                 None => None,
             };
-            if !finality::is_final(kas_http, &tx_id, hint).await? {
-                return Err(ValidationError::ImmatureTransaction {
+            if !finality::is_safe_against_reorg(kas_http, &tx_id, hint).await? {
+                return Err(ValidationError::NotSafeAgainstReorg {
                     tx_id: tx_id.clone(),
                 });
             }

--- a/dymension/libs/kaspa/lib/validator/src/confirmation.rs
+++ b/dymension/libs/kaspa/lib/validator/src/confirmation.rs
@@ -120,12 +120,17 @@ pub async fn validate_confirmed_withdrawals(
 
         // If the last TX in sequence is final then the others must be too
         if i == outpoints.len() - 1 {
-            let hash = RpcHash::from_str(
-                &tx.accepting_block_hash
-                    .ok_or_else(|| eyre::eyre!("No accepting block hash found in transaction"))?,
-            )
-            .map_err(|e| eyre::eyre!("Failed to convert accepting block hash to RpcHash: {}", e))?;
-            if !finality::is_tx_final(kas_rpc, hash, network_id).await? {
+            let hint = match tx.block_hash {
+                Some(block_hashes) => {
+                    if 0 < block_hashes.len() {
+                        Some(block_hashes[0].clone())
+                    } else {
+                        None
+                    }
+                }
+                None => None,
+            };
+            if !finality::is_final(kas_http, &tx_id, hint).await? {
                 return Err(ValidationError::ImmatureTransaction {
                     tx_id: tx_id.clone(),
                 });

--- a/dymension/libs/kaspa/lib/validator/src/confirmation.rs
+++ b/dymension/libs/kaspa/lib/validator/src/confirmation.rs
@@ -125,7 +125,7 @@ pub async fn validate_confirmed_withdrawals(
                     .ok_or_else(|| eyre::eyre!("No accepting block hash found in transaction"))?,
             )
             .map_err(|e| eyre::eyre!("Failed to convert accepting block hash to RpcHash: {}", e))?;
-            if !finality::validate_maturity_block(kas_rpc, hash, network_id).await? {
+            if !finality::is_tx_final(kas_rpc, hash, network_id).await? {
                 return Err(ValidationError::ImmatureTransaction {
                     tx_id: tx_id.clone(),
                 });

--- a/dymension/libs/kaspa/lib/validator/src/confirmation.rs
+++ b/dymension/libs/kaspa/lib/validator/src/confirmation.rs
@@ -8,6 +8,7 @@ use api_rs::models::TxModel;
 use corelib::finality;
 use corelib::payload::{MessageID, MessageIDs};
 use corelib::util;
+use hyperlane_cosmos_rs::dymensionxyz::dymension::kas::ProgressIndication;
 use kaspa_consensus_core::network::NetworkId;
 use kaspa_consensus_core::tx::{TransactionId, TransactionInput, TransactionOutpoint};
 use kaspa_hashes::Hash as KaspaHash;
@@ -21,105 +22,96 @@ use tracing::{info, warn};
 
 pub async fn validate_confirmed_withdrawals(
     fxg: &ConfirmationFXG,
-    kas_http: &HttpClient,
-    kas_rpc: &Arc<DynRpcApi>,
-    network_id: NetworkId,
+    client_rest: &HttpClient,
 ) -> Result<(), ValidationError> {
     info!("Validator: Starting validation of withdrawals confirmation");
 
-    let anchor_utxo = fxg
-        .progress_indication
-        .old_outpoint
-        .as_ref()
-        .ok_or_else(|| eyre::eyre!("Validator: Old outpoint missing in progress indication"))?;
+    let untrusted_progress = &fxg.progress_indication;
 
-    let new_utxo = fxg
-        .progress_indication
-        .new_outpoint
-        .as_ref()
-        .ok_or_else(|| eyre::eyre!("Validator: New outpoint missing in progress indication"))?;
-
-    // Convert progress indication outpoints to kaspa consensus types for comparison
-    let anchor_kaspa_outpoint = TransactionOutpoint {
-        transaction_id: KaspaHash::from_bytes(
-            anchor_utxo
-                .transaction_id
-                .as_slice()
-                .try_into()
-                .map_err(|e| {
-                    eyre::eyre!("Validator: Invalid anchor outpoint transaction ID: {}", e)
-                })?,
-        ),
-        index: anchor_utxo.index,
+    let proposed_hub_anchor_old = {
+        let o = untrusted_progress
+            .old_outpoint
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("Validator: Old outpoint missing in progress indication"))?;
+        TransactionOutpoint {
+            transaction_id: KaspaHash::from_bytes(o.transaction_id.as_slice().try_into().map_err(
+                |e| eyre::eyre!("Validator: Invalid anchor outpoint transaction ID: {}", e),
+            )?),
+            index: o.index,
+        }
     };
 
-    let new_kaspa_outpoint = TransactionOutpoint {
-        transaction_id: KaspaHash::from_bytes(
-            new_utxo.transaction_id.as_slice().try_into().map_err(|e| {
-                eyre::eyre!("Validator: Invalid new outpoint transaction ID: {}", e)
-            })?,
-        ),
-        index: new_utxo.index,
+    let proposed_hub_anchor_new = {
+        let o = untrusted_progress
+            .new_outpoint
+            .as_ref()
+            .ok_or_else(|| eyre::eyre!("Validator: New outpoint missing in progress indication"))?;
+        TransactionOutpoint {
+            transaction_id: KaspaHash::from_bytes(o.transaction_id.as_slice().try_into().map_err(
+                |e| eyre::eyre!("Validator: Invalid new outpoint transaction ID: {}", e),
+            )?),
+            index: o.index,
+        }
     };
 
     // Validate the progress indication is correct according to the cache
-    let outpoints = &fxg.cache.outpoints;
-    if outpoints.len() < 2 {
+    let outpoint_sequence = &fxg.cache.outpoints;
+    if outpoint_sequence.len() < 2 {
         return Err(ValidationError::SystemError(eyre::eyre!(
             "Validator: Insufficient outpoints in cache for validation"
         )));
     }
-    if outpoints[0] != anchor_kaspa_outpoint {
+    if outpoint_sequence[0] != proposed_hub_anchor_old {
         return Err(ValidationError::SystemError(eyre::eyre!(
             "Validator: Anchor outpoint mismatch in cache"
         )));
     }
-    if outpoints[outpoints.len() - 1] != new_kaspa_outpoint {
+    if outpoint_sequence[outpoint_sequence.len() - 1] != proposed_hub_anchor_new {
         return Err(ValidationError::SystemError(eyre::eyre!(
             "Validator: New outpoint mismatch in cache"
         )));
     }
 
-    let mut collected_message_ids = Vec::new();
+    let mut observed_message_ids = Vec::new();
 
     // Start from the next UTXO after the anchor_utxo (skip the first outpoint)
-    for (i, curr_outpoint) in outpoints.iter().enumerate().skip(1) {
+    for (i, o) in outpoint_sequence.iter().enumerate().skip(1) {
         info!(
             "Validator: Processing outpoint {} of {}: {:?}",
             i + 1,
-            outpoints.len(),
-            curr_outpoint
+            outpoint_sequence.len(),
+            o
         );
 
-        let tx_id = &curr_outpoint.transaction_id.to_string();
+        let tx_id = &o.transaction_id.to_string();
 
         // Get the transaction that CREATED this UTXO
-        let tx = kas_http.get_tx_by_id(tx_id).await.map_err(|e| {
+        let tx = client_rest.get_tx_by_id(tx_id).await.map_err(|e| {
             eyre::eyre!(
                 "Validator: Failed to get transaction {}: {}",
-                curr_outpoint.transaction_id,
+                o.transaction_id,
                 e
             )
         })?;
 
         // Validate that this transaction spends the previous outpoint
-        let prev_outpoint = &outpoints[i - 1]; // Previous outpoint in the chain
-        if !validate_previous_transaction_in_inputs(&tx, prev_outpoint)? {
+        let prev = &outpoint_sequence[i - 1]; // Previous outpoint in the chain
+        if !validate_previous_transaction_in_inputs(&tx, prev)? {
             return Err(ValidationError::SystemError(eyre::eyre!(
                 "Validator: Previous transaction not found in inputs"
             )));
         }
 
-        let payload = tx
+        let p = tx
             .payload
             .clone()
             .ok_or_else(|| eyre::eyre!("No payload found in transaction"))?;
 
-        let message_ids = MessageIDs::from_tx_payload(&payload)
+        let message_ids = MessageIDs::from_tx_payload(&p)
             .map_err(|e| eyre::eyre!("Failed to parse message IDs from payload: {}", e))?;
 
         // If the last TX in sequence is final then the others must be too
-        if i == outpoints.len() - 1 {
+        if i == outpoint_sequence.len() - 1 {
             let hint = match tx.block_hash {
                 Some(block_hashes) => {
                     if 0 < block_hashes.len() {
@@ -130,18 +122,18 @@ pub async fn validate_confirmed_withdrawals(
                 }
                 None => None,
             };
-            if !finality::is_safe_against_reorg(kas_http, &tx_id, hint).await? {
+            if !finality::is_safe_against_reorg(client_rest, &tx_id, hint).await? {
                 return Err(ValidationError::NotSafeAgainstReorg {
                     tx_id: tx_id.clone(),
                 });
             }
         }
 
-        collected_message_ids.extend(message_ids.0);
+        observed_message_ids.extend(message_ids.0);
     }
 
     // Assert that the collected messageIds are the same as progress_indication.processed_withdrawals
-    validate_message_ids_exactly_equal(fxg, &collected_message_ids)?;
+    validate_message_ids_exactly_equal(untrusted_progress, &observed_message_ids)?;
 
     info!("Validator: All validations passed successfully");
     Ok(())
@@ -184,27 +176,25 @@ fn validate_previous_transaction_in_inputs(
 
 /// Validate that the collected message IDs match the progress indication
 fn validate_message_ids_exactly_equal(
-    fxg: &ConfirmationFXG,
-    collected_message_ids: &[MessageID],
+    untrusted_progress: &ProgressIndication,
+    observed_message_ids: &[MessageID],
 ) -> Result<(), ValidationError> {
-    // Convert collected message IDs to the same format as progress indication
-    let expected_message_ids: HashSet<String> = collected_message_ids
+    let expected_message_ids: HashSet<String> = observed_message_ids
         .iter()
         .map(|id| hex::encode(id.0.as_bytes()))
         .collect();
 
-    let actual_message_ids: HashSet<String> = fxg
-        .progress_indication
+    let untrusted_message_ids: HashSet<String> = untrusted_progress
         .processed_withdrawals
         .iter()
         .map(|w| w.message_id.clone())
         .collect();
 
-    if expected_message_ids != actual_message_ids {
+    if expected_message_ids != untrusted_message_ids {
         return Err(ValidationError::SystemError(eyre::eyre!(
             "Validator: Message IDs mismatch - expected: {:?}, actual: {:?}",
             expected_message_ids,
-            actual_message_ids
+            untrusted_message_ids
         )));
     }
 

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -72,7 +72,7 @@ pub async fn validate_new_deposit_inner(
     /*
     TODO: INSECURE! NEED TO CHECK CLAIMED ACCEPTING BLOCK ACTUALLY ACCEPTS TX
       */
-    if !finality::validate_maturity_block(
+    if !finality::is_tx_final(
         client,
         d_untrusted.accepting_block_hash_rpc()?,
         net.network_id,

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -22,6 +22,7 @@ use eyre::Result;
 use hyperlane_core::U256;
 use kaspa_txscript::extract_script_pub_key_address;
 
+use corelib::api::client::HttpClient;
 use corelib::{confirmation::ConfirmationFXG, util, withdraw::WithdrawFXG};
 use hardcode::hl::ALLOWED_HL_MESSAGE_VERSION;
 use hyperlane_cosmos_native::GrpcProvider as CosmosGrpcClient;
@@ -58,7 +59,8 @@ pub async fn validate_new_deposit(
 /// Note: If the utxo value is higher of the amount the deposit is also accepted
 ///
 pub async fn validate_new_deposit_inner(
-    client: &Arc<DynRpcApi>,
+    node_client: &Arc<DynRpcApi>,
+    rest_client: &HttpClient,
     d_untrusted: &DepositFXG,
     net: &NetworkInfo,
     escrow_address: &Address,
@@ -69,13 +71,10 @@ pub async fn validate_new_deposit_inner(
         return Ok(false);
     }
 
-    /*
-    TODO: INSECURE! NEED TO CHECK CLAIMED ACCEPTING BLOCK ACTUALLY ACCEPTS TX
-      */
-    if !finality::is_tx_final(
-        client,
-        d_untrusted.accepting_block_hash_rpc()?,
-        net.network_id,
+    if !finality::is_final(
+        rest_client,
+        &d_untrusted.tx_id,
+        Some(d_untrusted.containing_block_hash_rpc()?.to_string()),
     )
     .await?
     {
@@ -94,7 +93,7 @@ pub async fn validate_new_deposit_inner(
         return Ok(false);
     }
 
-    let containing_block: RpcBlock = client
+    let containing_block: RpcBlock = node_client
         .get_block(d_untrusted.containing_block_hash_rpc()?, true)
         .await?;
 

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -39,13 +39,22 @@ use hyperlane_cosmos_native::GrpcProvider as CosmosGrpcClient;
 ///
 pub async fn validate_new_deposit(
     client: &Arc<DynRpcApi>,
+    rest_client: &HttpClient,
     deposit: &DepositFXG,
     net: &NetworkInfo,
     escrow_address: &Address,
     hub_client: &CosmosGrpcClient,
 ) -> Result<bool> {
     let hub_bootstrapped = hub_client.hub_bootstrapped().await?;
-    validate_new_deposit_inner(client, deposit, net, escrow_address, hub_bootstrapped).await
+    validate_new_deposit_inner(
+        client,
+        rest_client,
+        deposit,
+        net,
+        escrow_address,
+        hub_bootstrapped,
+    )
+    .await
 }
 
 /// Deposit validation process

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -38,8 +38,8 @@ use hyperlane_cosmos_native::GrpcProvider as CosmosGrpcClient;
 /// Note: If the utxo value is higher of the amount the deposit is also accepted
 ///
 pub async fn validate_new_deposit(
-    client: &Arc<DynRpcApi>,
-    rest_client: &HttpClient,
+    client_node: &Arc<DynRpcApi>,
+    client_rest: &HttpClient,
     deposit: &DepositFXG,
     net: &NetworkInfo,
     escrow_address: &Address,
@@ -47,8 +47,8 @@ pub async fn validate_new_deposit(
 ) -> Result<bool> {
     let hub_bootstrapped = hub_client.hub_bootstrapped().await?;
     validate_new_deposit_inner(
-        client,
-        rest_client,
+        client_node,
+        client_rest,
         deposit,
         net,
         escrow_address,
@@ -68,8 +68,8 @@ pub async fn validate_new_deposit(
 /// Note: If the utxo value is higher of the amount the deposit is also accepted
 ///
 pub async fn validate_new_deposit_inner(
-    node_client: &Arc<DynRpcApi>,
-    rest_client: &HttpClient,
+    client_node: &Arc<DynRpcApi>,
+    client_rest: &HttpClient,
     d_untrusted: &DepositFXG,
     net: &NetworkInfo,
     escrow_address: &Address,
@@ -81,7 +81,7 @@ pub async fn validate_new_deposit_inner(
     }
 
     if !finality::is_safe_against_reorg(
-        rest_client,
+        client_rest,
         &d_untrusted.tx_id,
         Some(d_untrusted.containing_block_hash_rpc()?.to_string()),
     )
@@ -102,7 +102,7 @@ pub async fn validate_new_deposit_inner(
         return Ok(false);
     }
 
-    let containing_block: RpcBlock = node_client
+    let containing_block: RpcBlock = client_node
         .get_block(d_untrusted.containing_block_hash_rpc()?, true)
         .await?;
 

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -80,7 +80,7 @@ pub async fn validate_new_deposit_inner(
         return Ok(false);
     }
 
-    if !finality::is_final(
+    if !finality::is_safe_against_reorg(
         rest_client,
         &d_untrusted.tx_id,
         Some(d_untrusted.containing_block_hash_rpc()?.to_string()),

--- a/dymension/libs/kaspa/lib/validator/src/error.rs
+++ b/dymension/libs/kaspa/lib/validator/src/error.rs
@@ -11,8 +11,8 @@ pub enum ValidationError {
     #[error("HL message: mismatched domain or recipient")]
     IncorrectHLMessage,
 
-    #[error("Immature transaction: {tx_id}")]
-    ImmatureTransaction { tx_id: String },
+    #[error("Transaction is not safe against reorg: {tx_id}")]
+    NotSafeAgainstReorg { tx_id: String },
 
     #[error("Message is for another bridge: {message_id}")]
     MessageWrongBridge { message_id: String },

--- a/rust/main/chains/dymension-kaspa/src/validator_server.rs
+++ b/rust/main/chains/dymension-kaspa/src/validator_server.rs
@@ -179,14 +179,9 @@ async fn respond_validate_confirmed_withdrawals<S: HyperlaneSignerExt + Send + S
         .toggles
         .withdrawal_confirmation_enabled
     {
-        validate_confirmed_withdrawals(
-            &confirmation_fxg,
-            resources.must_rest_client(),
-            &resources.must_wallet().api(),
-            resources.must_wallet().net.network_id,
-        )
-        .await
-        .map_err(|e| AppError(Report::from(e)))?;
+        validate_confirmed_withdrawals(&confirmation_fxg, resources.must_rest_client())
+            .await
+            .map_err(|e| AppError(Report::from(e)))?;
         info!("Validator: confirmed withdrawal is valid");
     }
 

--- a/rust/main/chains/dymension-kaspa/src/validator_server.rs
+++ b/rust/main/chains/dymension-kaspa/src/validator_server.rs
@@ -124,6 +124,7 @@ async fn respond_validate_new_deposits<S: HyperlaneSignerExt + Send + Sync + 'st
     if resources.must_val_stuff().toggles.deposit_enabled
         && !validate_new_deposit(
             &resources.must_api(),
+            &resources.must_rest_client(),
             &deposits,
             &resources.must_wallet().net,
             &resources.must_escrow().addr,


### PR DESCRIPTION
- Use finality measure based on REST API accepting block blue score and virtual blue score
- See the constant defintiion https://github.com/dymensionxyz/hyperlane-monorepo/blob/cb0647a9cd5cedfc9a17e748f14e8b39bd640a9b/dymension/libs/kaspa/lib/hardcode/src/tx.rs#L4-L34
- Also only confirms finality for LAST tx in confirmation validation
- Only queries accepted deposits
- Forces use of REST server in validations (we will have mzonder or validators run their own server)
- Relayer withdrawawl TX construction still uses old definition of maturity as this is fine for wallets
- Has practical impact of requires **100 seconds** for finality