### PR TITLE
fix: sig hash identity check

### DIFF
--- a/dymension/libs/kaspa/lib/core/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/core/src/deposit.rs
@@ -99,6 +99,7 @@ mod tests {
             utxo_index: 5,
             amount: U256::from(100_000_000),
             accepting_block_hash: "test_block_id_abc".to_string(),
+            containing_block_hash: "test_block_id_def".to_string(),
             hl_message: HyperlaneMessage::default(),
         };
 
@@ -153,6 +154,7 @@ mod tests {
         let deposit1 = DepositFXG {
             tx_id: "deterministic_tx".to_string(),
             utxo_index: 10,
+            containing_block_hash: "deterministic_block".to_string(),
             accepting_block_hash: "deterministic_block".to_string(),
             amount: U256::from(100_000_000),
             hl_message: HyperlaneMessage {
@@ -169,6 +171,7 @@ mod tests {
         let deposit2 = DepositFXG {
             tx_id: "deterministic_tx".to_string(),
             utxo_index: 10,
+            containing_block_hash: "deterministic_block".to_string(),
             accepting_block_hash: "deterministic_block".to_string(),
             amount: U256::from(100_000_000),
             hl_message: HyperlaneMessage {

--- a/dymension/libs/kaspa/lib/core/src/util.rs
+++ b/dymension/libs/kaspa/lib/core/src/util.rs
@@ -30,8 +30,11 @@ pub fn input_sighash_type() -> SigHashType {
     SigHashType::from_u8(SIG_HASH_ALL.to_u8() | SIG_HASH_ANY_ONE_CAN_PAY.to_u8()).unwrap()
 }
 
-pub fn check_sighash_type(t: SigHashType) -> bool {
-    t.is_sighash_all() && t.is_sighash_anyone_can_pay()
+pub fn is_valid_sighash_type(t: SigHashType) -> bool {
+    return t.to_u8()
+        == (SigHashType::from_u8(SIG_HASH_ALL.to_u8() | SIG_HASH_ANY_ONE_CAN_PAY.to_u8())
+            .unwrap())
+        .to_u8();
 }
 
 /// Find the first duplicate if any.
@@ -49,6 +52,6 @@ mod tests {
 
     #[test]
     fn test_input_sighash_type() {
-        assert!(check_sighash_type(input_sighash_type()));
+        assert!(is_valid_sighash_type(input_sighash_type()));
     }
 }

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
@@ -627,7 +627,7 @@ pub async fn sign_pay_fee(pskt: PSKT<Signer>, w: &Arc<Wallet>, s: &Secret) -> Re
 mod tests {
     use super::*;
     use bytes::Bytes;
-    use corelib::util::check_sighash_type;
+    use corelib::util::is_valid_sighash_type;
     use corelib::withdraw::WithdrawFXG;
     use std::collections::BTreeMap;
 
@@ -785,7 +785,7 @@ mod tests {
 
         // Verify sighash type
         let sighash_type_1 = pskt.inputs.first().unwrap().sighash_type;
-        assert!(check_sighash_type(sighash_type_1));
+        assert!(is_valid_sighash_type(sighash_type_1));
 
         // Create WithdrawFXG
         let bundle = Bundle::from(pskt);
@@ -818,7 +818,7 @@ mod tests {
             .unwrap()
             .sighash_type;
 
-        assert!(check_sighash_type(sighash_type_2));
+        assert!(is_valid_sighash_type(sighash_type_2));
 
         Ok(())
     }

--- a/dymension/libs/kaspa/lib/validator/src/withdraw.rs
+++ b/dymension/libs/kaspa/lib/validator/src/withdraw.rs
@@ -12,7 +12,7 @@ use secp256k1::Keypair as SecpKeypair;
 use crate::error::ValidationError;
 use corelib::payload::{MessageID, MessageIDs};
 use corelib::util;
-use corelib::util::{check_sighash_type, get_recipient_address, get_recipient_script_pubkey};
+use corelib::util::{get_recipient_address, get_recipient_script_pubkey, is_valid_sighash_type};
 use corelib::wallet::EasyKaspaWallet;
 use corelib::withdraw::{filter_pending_withdrawals, WithdrawFXG};
 use eyre::{Report, Result};
@@ -247,7 +247,7 @@ pub fn validate_pskt(
     let incorrect_sig_hash = pskt
         .inputs
         .iter()
-        .any(|input| !check_sighash_type(input.sighash_type));
+        .any(|input| !is_valid_sighash_type(input.sighash_type));
     if incorrect_sig_hash {
         return Err(ValidationError::IncorrectSigHashType);
     }


### PR DESCRIPTION
Might not have been a real exploit but simpler to just exclude it completely


    fn test_sighash_type_variants() {
        let x = SigHashType(0b10001001);
        let y = SigHashType::from_u8(SIG_HASH_ALL.to_u8() | SIG_HASH_ANY_ONE_CAN_PAY.to_u8()).unwrap();
        assert!(x.to_u8() != y.to_u8());
        assert!(x.is_sighash_all());
        assert!(x.is_sighash_anyone_can_pay());
    }