### PR TITLE
feat: populate HlMetadata in deposit payload

### DIFF
--- a/dymension/libs/kaspa/lib/core/src/user/payload.rs
+++ b/dymension/libs/kaspa/lib/core/src/user/payload.rs
@@ -1,6 +1,8 @@
 use hyperlane_core::{Encode, HyperlaneMessage, H256, U256};
 use hyperlane_cosmos_native::signers::Signer;
+use hyperlane_cosmos_rs::dymensionxyz::dymension::forward::HlMetadata;
 use hyperlane_warp_route::TokenMessage;
+use prost::Message as _;
 
 /*
 Need to make a hub priv key and address pair
@@ -54,7 +56,14 @@ pub fn make_deposit_payload(
 }
 
 fn make_deposit_payload_meta() -> Vec<u8> {
-    let buf = vec![];
-    // TODO:
-    buf
+    // Create an empty HlMetadata struct with all required fields
+    // The kaspa field will be populated later in the message flow
+    let metadata = HlMetadata {
+        kaspa: vec![],
+        hook_forward_to_hl: vec![],
+        hook_forward_to_ibc: vec![],
+    };
+
+    // Encode the metadata to protobuf bytes
+    metadata.encode_to_vec()
 }


### PR DESCRIPTION
## Summary
- Implement `make_deposit_payload_meta()` function to properly populate token message metadata
- Add required protobuf encoding imports and HlMetadata struct usage
- Initialize all required metadata fields with empty values

## Context
This change is required after PR #209 which now validates that `token_message.metadata` is not empty. The metadata needs to be properly encoded as protobuf bytes.

## Changes
- Added imports for `HlMetadata` from `hyperlane_cosmos_rs` and `prost::Message`
- Replaced TODO stub with actual implementation that creates and encodes HlMetadata
- All fields (kaspa, hook_forward_to_hl, hook_forward_to_ibc) are initialized as empty vectors
- The kaspa field will be populated later in the message flow

## Test Plan
- [x] Code compiles successfully
- [x] Cargo check passes
- [ ] Integration tests pass (requires full test suite run)

🤖 Generated with [Claude Code](https://claude.ai/code)