### PR TITLE
feat: use strongly typed errors for deposit and confirmation validation

### DIFF
--- a/dymension/libs/kaspa/demo/relayer/src/x/deposit.rs
+++ b/dymension/libs/kaspa/demo/relayer/src/x/deposit.rs
@@ -243,11 +243,7 @@ pub async fn demo(args: DemoArgs) -> Result<(), Box<dyn Error>> {
     )
     .await?;
 
-    if validation_result {
-        println!("Deposit validated");
-    } else {
-        println!("Failed to validate deposit");
-    }
+    println!("Deposit validated");
 
     Ok(())
 }

--- a/dymension/libs/kaspa/lib/validator/src/confirmation.rs
+++ b/dymension/libs/kaspa/lib/validator/src/confirmation.rs
@@ -127,7 +127,12 @@ pub async fn validate_confirmed_withdrawals(
                 }
                 None => None,
             };
-            if !finality::is_safe_against_reorg(client_rest, tx_id, hint).await? {
+            if !finality::is_safe_against_reorg(client_rest, tx_id, hint)
+                .await
+                .map_err(|e| ValidationError::ExternalApiError {
+                    reason: e.to_string(),
+                })?
+            {
                 return Err(ValidationError::NotSafeAgainstReorg {
                     tx_id: tx_id.clone(),
                 });

--- a/dymension/libs/kaspa/lib/validator/src/confirmation.rs
+++ b/dymension/libs/kaspa/lib/validator/src/confirmation.rs
@@ -28,13 +28,13 @@ pub async fn validate_confirmed_withdrawals(
 
     let proposed_hub_anchor_old = {
         let o = untrusted_progress.old_outpoint.as_ref().ok_or_else(|| {
-            ValidationError::FailedGeneralVerification {
-                reason: "Old outpoint missing in progress indication".to_string(),
+            ValidationError::OutpointMissing {
+                description: "old outpoint in progress indication".to_string(),
             }
         })?;
         TransactionOutpoint {
             transaction_id: KaspaHash::from_bytes(o.transaction_id.as_slice().try_into().map_err(
-                |e| ValidationError::FailedGeneralVerification {
+                |e| ValidationError::InvalidOutpointData {
                     reason: format!("Invalid anchor outpoint transaction ID: {}", e),
                 },
             )?),
@@ -44,13 +44,13 @@ pub async fn validate_confirmed_withdrawals(
 
     let proposed_hub_anchor_new = {
         let o = untrusted_progress.new_outpoint.as_ref().ok_or_else(|| {
-            ValidationError::FailedGeneralVerification {
-                reason: "New outpoint missing in progress indication".to_string(),
+            ValidationError::OutpointMissing {
+                description: "new outpoint in progress indication".to_string(),
             }
         })?;
         TransactionOutpoint {
             transaction_id: KaspaHash::from_bytes(o.transaction_id.as_slice().try_into().map_err(
-                |e| ValidationError::FailedGeneralVerification {
+                |e| ValidationError::InvalidOutpointData {
                     reason: format!("Invalid new outpoint transaction ID: {}", e),
                 },
             )?),
@@ -61,8 +61,8 @@ pub async fn validate_confirmed_withdrawals(
     // Validate the progress indication is correct according to the cache
     let outpoint_sequence = &fxg.outpoints;
     if outpoint_sequence.len() < 2 {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: "Insufficient outpoints in cache for validation".to_string(),
+        return Err(ValidationError::InsufficientOutpoints {
+            count: outpoint_sequence.len(),
         });
     }
     if outpoint_sequence[0] != proposed_hub_anchor_old {
@@ -90,18 +90,16 @@ pub async fn validate_confirmed_withdrawals(
         let tx_id = &o.transaction_id.to_string();
 
         // Get the transaction that CREATED this UTXO
-        let tx = client_rest.get_tx_by_id(tx_id).await.map_err(|e| {
-            ValidationError::FailedGeneralVerification {
-                reason: format!("Failed to get transaction {}: {}", o.transaction_id, e),
+        let tx = client_rest.get_tx_by_id(tx_id).await.map_err(|_| {
+            ValidationError::TransactionFetchError {
+                tx_id: o.transaction_id.to_string(),
             }
         })?;
 
         // Validate that this transaction spends the previous outpoint
         let o_prev = &outpoint_sequence[i - 1]; // Previous outpoint in the chain
         if !outpoint_in_inputs(&tx, o_prev)? {
-            return Err(ValidationError::FailedGeneralVerification {
-                reason: "Previous transaction not found in inputs".to_string(),
-            });
+            return Err(ValidationError::PreviousTransactionNotFound);
         }
 
         // Validate that this transaction creates the current outpoint
@@ -110,15 +108,12 @@ pub async fn validate_confirmed_withdrawals(
         let p = tx
             .payload
             .clone()
-            .ok_or_else(|| ValidationError::FailedGeneralVerification {
-                reason: "No payload found in transaction".to_string(),
-            })?;
+            .ok_or(ValidationError::MissingTransactionPayload)?;
 
-        let message_ids = MessageIDs::from_tx_payload(&p).map_err(|e| {
-            ValidationError::FailedGeneralVerification {
-                reason: format!("Failed to parse message IDs from payload: {}", e),
-            }
-        })?;
+        let message_ids =
+            MessageIDs::from_tx_payload(&p).map_err(|e| ValidationError::PayloadParseError {
+                reason: format!("Failed to parse message IDs: {}", e),
+            })?;
 
         // If the last TX in sequence is final then the others must be too
         if i == outpoint_sequence.len() - 1 {
@@ -154,29 +149,26 @@ fn outpoint_in_inputs(
     transaction: &TxModel,
     anchor: &TransactionOutpoint,
 ) -> Result<bool, ValidationError> {
-    let inputs =
-        transaction
-            .inputs
-            .as_ref()
-            .ok_or_else(|| ValidationError::FailedGeneralVerification {
-                reason: "Transaction inputs not found".to_string(),
-            })?;
+    let inputs = transaction
+        .inputs
+        .as_ref()
+        .ok_or(ValidationError::MissingTransactionInputs)?;
 
     for input in inputs {
         // Properly decode the hex values like in the relayer
         let input_utxo = TransactionOutpoint {
             transaction_id: kaspa_hashes::Hash::from_bytes(
                 hex::decode(&input.previous_outpoint_hash)
-                    .map_err(|e| ValidationError::FailedGeneralVerification {
+                    .map_err(|e| ValidationError::InvalidOutpointData {
                         reason: format!("Invalid hex in previous_outpoint_hash: {}", e),
                     })?
                     .try_into()
-                    .map_err(|_| ValidationError::FailedGeneralVerification {
+                    .map_err(|_| ValidationError::InvalidOutpointData {
                         reason: "Invalid hex length in previous_outpoint_hash".to_string(),
                     })?,
             ),
             index: input.previous_outpoint_index.parse().map_err(|e| {
-                ValidationError::FailedGeneralVerification {
+                ValidationError::InvalidOutpointData {
                     reason: format!("Failed to parse previous_outpoint_index: {}", e),
                 }
             })?,
@@ -197,13 +189,10 @@ fn escrow_outpoint_in_outputs(
     escrow_outpoint_unstrusted: &TransactionOutpoint,
     escrow_address: &Address,
 ) -> Result<(), ValidationError> {
-    let outs =
-        tx_trusted
-            .outputs
-            .as_ref()
-            .ok_or_else(|| ValidationError::FailedGeneralVerification {
-                reason: "Transaction outputs not found".to_string(),
-            })?;
+    let outs = tx_trusted
+        .outputs
+        .as_ref()
+        .ok_or(ValidationError::MissingTransactionOutputs)?;
 
     let out_actual: &TxOutput = outs
         .get(escrow_outpoint_unstrusted.index as usize)
@@ -215,9 +204,7 @@ fn escrow_outpoint_in_outputs(
     let recipient_actual = out_actual
         .script_public_key_address
         .clone()
-        .ok_or_else(|| ValidationError::FailedGeneralVerification {
-            reason: "No script public key address found in anchor output".to_string(),
-        })?;
+        .ok_or(ValidationError::MissingScriptPubKeyAddress)?;
 
     if recipient_actual != escrow_address.address_to_string() {
         return Err(ValidationError::NonEscrowAnchor {
@@ -245,12 +232,7 @@ fn validate_message_ids_exactly_equal(
         .collect();
 
     if expected_message_ids != untrusted_message_ids {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: format!(
-                "Message IDs mismatch - expected: {:?}, actual: {:?}",
-                expected_message_ids, untrusted_message_ids
-            ),
-        });
+        return Err(ValidationError::MessageIdsMismatch);
     }
 
     Ok(())

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -111,10 +111,13 @@ pub async fn validate_new_deposit(
     hub_client: &CosmosGrpcClient,
     must_match: MustMatch,
 ) -> Result<(), ValidationError> {
-    let hub_bootstrapped = hub_client
-        .hub_bootstrapped()
-        .await
-        .map_err(|e| ValidationError::SystemError(e.into()))?;
+    let hub_bootstrapped =
+        hub_client
+            .hub_bootstrapped()
+            .await
+            .map_err(|e| ValidationError::HubQueryError {
+                reason: e.to_string(),
+            })?;
     validate_new_deposit_inner(
         client_node,
         client_rest,
@@ -154,9 +157,11 @@ pub async fn validate_new_deposit_inner(
         return Err(ValidationError::InvalidTransactionHash);
     }
 
-    let containing_block_hash = d_untrusted
-        .containing_block_hash_rpc()
-        .map_err(|e| ValidationError::SystemError(e.into()))?;
+    let containing_block_hash = d_untrusted.containing_block_hash_rpc().map_err(|e| {
+        ValidationError::BlockHashConversionError {
+            reason: e.to_string(),
+        }
+    })?;
 
     if !finality::is_safe_against_reorg(
         client_rest,
@@ -164,8 +169,9 @@ pub async fn validate_new_deposit_inner(
         Some(containing_block_hash.to_string()),
     )
     .await
-    .map_err(|e| ValidationError::SystemError(e.into()))?
-    {
+    .map_err(|e| ValidationError::ExternalApiError {
+        reason: e.to_string(),
+    })? {
         return Err(ValidationError::NotSafeAgainstReorg {
             tx_id: d_untrusted.tx_id.clone(),
         });
@@ -174,11 +180,16 @@ pub async fn validate_new_deposit_inner(
     let containing_block: RpcBlock = client_node
         .get_block(containing_block_hash, true)
         .await
-        .map_err(|e| ValidationError::SystemError(e.into()))?;
+        .map_err(|e| ValidationError::KaspaNodeError {
+            reason: e.to_string(),
+        })?;
 
-    let tx_id_rpc = d_untrusted
-        .tx_id_rpc()
-        .map_err(|e| ValidationError::SystemError(e.into()))?;
+    let tx_id_rpc =
+        d_untrusted
+            .tx_id_rpc()
+            .map_err(|e| ValidationError::TransactionHashConversionError {
+                reason: e.to_string(),
+            })?;
 
     let actual_deposit = tx_by_id(&containing_block, &tx_id_rpc)?;
 

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -54,43 +54,38 @@ impl MustMatch {
             return Ok(());
         }
         if self.partial_message.version != other.version {
-            return Err(ValidationError::FailedGeneralVerification {
-                reason: format!(
-                    "version is incorrect, expected: {}, got: {}",
-                    self.partial_message.version, other.version
-                ),
+            return Err(ValidationError::HLMessageFieldMismatch {
+                field: "version".to_string(),
+                expected: self.partial_message.version.to_string(),
+                actual: other.version.to_string(),
             });
         }
         if self.partial_message.origin != other.origin {
-            return Err(ValidationError::FailedGeneralVerification {
-                reason: format!(
-                    "origin is incorrect, expected: {}, got: {}",
-                    self.partial_message.origin, other.origin
-                ),
+            return Err(ValidationError::HLMessageFieldMismatch {
+                field: "origin".to_string(),
+                expected: self.partial_message.origin.to_string(),
+                actual: other.origin.to_string(),
             });
         }
         if self.partial_message.sender != other.sender {
-            return Err(ValidationError::FailedGeneralVerification {
-                reason: format!(
-                    "sender is incorrect, expected: {}, got: {}",
-                    self.partial_message.sender, other.sender
-                ),
+            return Err(ValidationError::HLMessageFieldMismatch {
+                field: "sender".to_string(),
+                expected: format!("{:?}", self.partial_message.sender),
+                actual: format!("{:?}", other.sender),
             });
         }
         if self.partial_message.destination == other.destination {
-            return Err(ValidationError::FailedGeneralVerification {
-                reason: format!(
-                    "destination is incorrect, expected: {}, got: {}",
-                    self.partial_message.destination, other.destination
-                ),
+            return Err(ValidationError::HLMessageFieldMismatch {
+                field: "destination".to_string(),
+                expected: format!("!= {}", self.partial_message.destination),
+                actual: other.destination.to_string(),
             });
         }
         if self.partial_message.recipient != other.recipient {
-            return Err(ValidationError::FailedGeneralVerification {
-                reason: format!(
-                    "recipient is incorrect, expected: {}, got: {}",
-                    self.partial_message.recipient, other.recipient
-                ),
+            return Err(ValidationError::HLMessageFieldMismatch {
+                field: "recipient".to_string(),
+                expected: format!("{:?}", self.partial_message.recipient),
+                actual: format!("{:?}", other.recipient),
             });
         }
         Ok(())
@@ -152,15 +147,11 @@ pub async fn validate_new_deposit_inner(
     must_match: MustMatch,
 ) -> Result<(), ValidationError> {
     if !hub_bootstrapped {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: "Hub is not bootstrapped, cannot validate deposit".to_string(),
-        });
+        return Err(ValidationError::HubNotBootstrapped);
     }
 
     if d_untrusted.tx_id_rpc().is_err() {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: "Deposit tx hash is not valid".to_string(),
-        });
+        return Err(ValidationError::InvalidTransactionHash);
     }
 
     let containing_block_hash = d_untrusted
@@ -195,14 +186,14 @@ pub async fn validate_new_deposit_inner(
     let actual_deposit_utxo: &RpcTransactionOutput = actual_deposit
         .outputs
         .get(d_untrusted.utxo_index)
-        .ok_or_else(|| ValidationError::FailedGeneralVerification {
-            reason: "utxo not found by index".to_string(),
+        .ok_or_else(|| ValidationError::UtxoNotFound {
+            index: d_untrusted.utxo_index,
         })?;
 
     // get HLMessage and token message from Tx payload
     let actual_hl_message = ParsedHL::parse_bytes(actual_deposit.payload).map_err(|e| {
-        ValidationError::FailedGeneralVerification {
-            reason: format!("Failed to parse HL message from payload: {}", e),
+        ValidationError::PayloadParseError {
+            reason: e.to_string(),
         }
     })?;
 
@@ -212,41 +203,34 @@ pub async fn validate_new_deposit_inner(
     // recreate the metadata injection to the token message done by the relayer
     let actual_hl_message_with_injected_info =
         add_kaspa_metadata_hl_messsage(actual_hl_message, tx_id_rpc, d_untrusted.utxo_index)
-            .map_err(|e| ValidationError::FailedGeneralVerification {
-                reason: format!("Failed to add Kaspa metadata to HL message: {}", e),
+            .map_err(|e| ValidationError::PayloadParseError {
+                reason: format!("Failed to add Kaspa metadata: {}", e),
             })?;
 
     must_match.is_match(&actual_hl_message_with_injected_info)?;
 
     // validate the original HL message included in the Kaspa Tx its the same than the HL message relayed, after adding the metadata.
     if d_untrusted.hl_message.id() != actual_hl_message_with_injected_info.id() {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: "Relayed HL message does not match HL message included in Kaspa Tx".to_string(),
-        });
+        return Err(ValidationError::HLMessageIdMismatch);
     }
 
     // deposit covers HL message amount?
     if U256::from(actual_deposit_utxo.value) < actual_hl_amt {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: format!(
-                "Deposit amount is less than token message amount, deposit: {:?}, token message: {:?}",
-                U256::from(actual_deposit_utxo.value),
-                actual_hl_amt
-            ),
+        return Err(ValidationError::InsufficientDepositAmount {
+            required: actual_hl_amt.to_string(),
+            actual: U256::from(actual_deposit_utxo.value).to_string(),
         });
     }
 
     let actual_utxo_addr =
         extract_script_pub_key_address(&actual_deposit_utxo.script_public_key, net.address_prefix)
-            .map_err(|e| ValidationError::FailedGeneralVerification {
-                reason: format!("Failed to extract script public key address: {}", e),
+            .map_err(|e| ValidationError::ScriptPubKeyExtractionError {
+                reason: e.to_string(),
             })?;
     if actual_utxo_addr != *escrow_address {
-        return Err(ValidationError::FailedGeneralVerification {
-            reason: format!(
-                "Deposit is not to escrow address, escrow: {:?}, utxo: {:?}",
-                escrow_address, actual_deposit_utxo.script_public_key
-            ),
+        return Err(ValidationError::WrongDepositAddress {
+            expected: escrow_address.to_string(),
+            actual: actual_utxo_addr.to_string(),
         });
     }
 
@@ -258,15 +242,11 @@ fn tx_by_id(block: &RpcBlock, tx_id: &RpcHash) -> Result<RpcTransaction, Validat
     let tx_index_actual = block
         .verbose_data
         .as_ref()
-        .ok_or_else(|| ValidationError::FailedGeneralVerification {
-            reason: "block data not found".to_string(),
-        })?
+        .ok_or(ValidationError::TransactionDataNotFound)?
         .transaction_ids
         .iter()
         .position(|id| id == tx_id)
-        .ok_or_else(|| ValidationError::FailedGeneralVerification {
-            reason: "transaction not found in block".to_string(),
-        })?;
+        .ok_or(ValidationError::TransactionDataNotFound)?;
 
     Ok(block.transactions[tx_index_actual].clone())
 }

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -16,7 +16,6 @@ use kaspa_rpc_core::{RpcHash, RpcTransaction, RpcTransactionOutput};
 use kaspa_txscript::extract_script_pub_key_address;
 use kaspa_wallet_core::prelude::DynRpcApi;
 use std::sync::Arc;
-use tracing::error;
 
 #[derive(Clone, Default)]
 pub struct MustMatch {

--- a/dymension/libs/kaspa/lib/validator/src/error.rs
+++ b/dymension/libs/kaspa/lib/validator/src/error.rs
@@ -11,11 +11,72 @@ pub enum ValidationError {
     #[error("HL message: mismatched domain or recipient")]
     IncorrectHLMessage,
 
+    #[error("HL message field mismatch - {field}: expected {expected}, got {actual}")]
+    HLMessageFieldMismatch {
+        field: String,
+        expected: String,
+        actual: String,
+    },
+
     #[error("Transaction is not safe against reorg: {tx_id}")]
     NotSafeAgainstReorg { tx_id: String },
 
     #[error("Message is for another bridge: {message_id}")]
     MessageWrongBridge { message_id: String },
+
+    #[error("Hub is not bootstrapped")]
+    HubNotBootstrapped,
+
+    #[error("Invalid transaction hash")]
+    InvalidTransactionHash,
+
+    #[error("UTXO not found at index {index}")]
+    UtxoNotFound { index: usize },
+
+    #[error("Failed to parse payload: {reason}")]
+    PayloadParseError { reason: String },
+
+    #[error("Insufficient deposit amount: required {required}, got {actual}")]
+    InsufficientDepositAmount { required: String, actual: String },
+
+    #[error("Deposit not to escrow address: expected {expected}, got {actual}")]
+    WrongDepositAddress { expected: String, actual: String },
+
+    #[error("Transaction data not found in block")]
+    TransactionDataNotFound,
+
+    #[error("Outpoint missing: {description}")]
+    OutpointMissing { description: String },
+
+    #[error("Invalid outpoint data: {reason}")]
+    InvalidOutpointData { reason: String },
+
+    #[error("Insufficient outpoints in cache: minimum 2 required, got {count}")]
+    InsufficientOutpoints { count: usize },
+
+    #[error("Previous transaction not found in inputs")]
+    PreviousTransactionNotFound,
+
+    #[error("Transaction has no payload")]
+    MissingTransactionPayload,
+
+    #[error("Transaction inputs not found")]
+    MissingTransactionInputs,
+
+    #[error("Transaction outputs not found")]
+    MissingTransactionOutputs,
+
+    #[error("Script public key address not found in output")]
+    MissingScriptPubKeyAddress,
+
+    #[error("Failed to extract script public key address: {reason}")]
+    ScriptPubKeyExtractionError { reason: String },
+
+    #[error("Message IDs do not match")]
+    MessageIdsMismatch,
+
+    #[error("HL message ID mismatch after metadata injection")]
+    HLMessageIdMismatch,
 
     #[error("Failed general verification: {reason}")]
     FailedGeneralVerification { reason: String },
@@ -77,6 +138,9 @@ pub enum ValidationError {
         input_amount: u64,
         output_amount: u64,
     },
+
+    #[error("Failed to get transaction: {tx_id}")]
+    TransactionFetchError { tx_id: String },
 
     #[error("{0}")]
     SystemError(#[from] eyre::Report),

--- a/dymension/libs/kaspa/lib/validator/src/error.rs
+++ b/dymension/libs/kaspa/lib/validator/src/error.rs
@@ -8,10 +8,7 @@ pub enum ValidationError {
     #[error("The same message was relayed twice: {message_id}")]
     DoubleSpending { message_id: String },
 
-    #[error("HL message: mismatched domain or recipient")]
-    IncorrectHLMessage,
-
-    #[error("HL message field mismatch - {field}: expected {expected}, got {actual}")]
+    #[error("HL message field mismatch: field={field} expected={expected} actual={actual}")]
     HLMessageFieldMismatch {
         field: String,
         expected: String,
@@ -20,9 +17,6 @@ pub enum ValidationError {
 
     #[error("Transaction is not safe against reorg: {tx_id}")]
     NotSafeAgainstReorg { tx_id: String },
-
-    #[error("Message is for another bridge: {message_id}")]
-    MessageWrongBridge { message_id: String },
 
     #[error("Hub is not bootstrapped")]
     HubNotBootstrapped,
@@ -36,10 +30,10 @@ pub enum ValidationError {
     #[error("Failed to parse payload: {reason}")]
     PayloadParseError { reason: String },
 
-    #[error("Insufficient deposit amount: required {required}, got {actual}")]
+    #[error("Insufficient deposit amount: required={required} actual={actual}")]
     InsufficientDepositAmount { required: String, actual: String },
 
-    #[error("Deposit not to escrow address: expected {expected}, got {actual}")]
+    #[error("Deposit not to escrow address: expected={expected} actual={actual}")]
     WrongDepositAddress { expected: String, actual: String },
 
     #[error("Transaction data not found in block")]
@@ -51,7 +45,7 @@ pub enum ValidationError {
     #[error("Invalid outpoint data: {reason}")]
     InvalidOutpointData { reason: String },
 
-    #[error("Insufficient outpoints in cache: minimum 2 required, got {count}")]
+    #[error("Insufficient outpoints in cache: minimum_required=2 actual_count={count}")]
     InsufficientOutpoints { count: usize },
 
     #[error("Previous transaction not found in inputs")]
@@ -87,18 +81,16 @@ pub enum ValidationError {
     #[error("HL message used escrow address as withdrawal recipient")]
     EscrowWithdrawalNotAllowed { message_id: String },
 
-    #[error("Anchor {o:?} not found in PSKT inputs")]
+    #[error("Anchor not found in PSKT inputs: outpoint={o:?}")]
     AnchorNotFound { o: TransactionOutpoint },
 
-    #[error("Anchor {o:?} is not escrow change")]
+    #[error("Anchor is not escrow change: outpoint={o:?}")]
     NonEscrowAnchor { o: TransactionOutpoint },
 
     #[error("No messages to validate")]
     NoMessages,
 
-    #[error(
-        "Relayer Hub anchor {hub_anchor:?} does not match withdrawal Hub anchor {relayer_anchor:?}"
-    )]
+    #[error("Hub anchor mismatch: hub_anchor={hub_anchor:?} relayer_anchor={relayer_anchor:?}")]
     HubAnchorMismatch {
         hub_anchor: TransactionOutpoint,
         relayer_anchor: TransactionOutpoint,
@@ -106,9 +98,6 @@ pub enum ValidationError {
 
     #[error("Sighash type is not SIG_HASH_ALL | SIG_HASH_ANY_ONE_CAN_PAY")]
     SigHashType,
-
-    #[error("PSKT should not have lock time")]
-    LockTime,
 
     #[error("Next anchor not found in PSKT outputs")]
     NextAnchorNotFound,
@@ -119,21 +108,16 @@ pub enum ValidationError {
     #[error("PSKT payload doesn't match inteded HL messages")]
     PayloadMismatch,
 
-    #[error("PSKT has incorrect TX version")]
-    TxVersionMismatch,
-
-    #[error("Outpoint {o:?} not found in PSKT chain")]
+    #[error("Outpoint not found in PSKT chain: outpoint={o:?}")]
     AnchorMismatch { o: TransactionOutpoint },
 
-    #[error("Message cache length mismatch: {expected} != {actual}")]
+    #[error("Message cache length mismatch: expected={expected} actual={actual}")]
     MessageCacheLengthMismatch { expected: usize, actual: usize },
 
     #[error("Some HL messages do not have outputs")]
     MissingOutputs,
 
-    #[error(
-        "Escrow input amount {input_amount} does not match escrow output amount {output_amount}"
-    )]
+    #[error("Escrow amount mismatch: input_amount={input_amount} output_amount={output_amount}")]
     EscrowAmountMismatch {
         input_amount: u64,
         output_amount: u64,
@@ -142,6 +126,18 @@ pub enum ValidationError {
     #[error("Failed to get transaction: {tx_id}")]
     TransactionFetchError { tx_id: String },
 
-    #[error("{0}")]
-    SystemError(#[from] eyre::Report),
+    #[error("External API error: {reason}")]
+    ExternalApiError { reason: String },
+
+    #[error("Block hash conversion error: {reason}")]
+    BlockHashConversionError { reason: String },
+
+    #[error("Transaction hash conversion error: {reason}")]
+    TransactionHashConversionError { reason: String },
+
+    #[error("Hub query error: {reason}")]
+    HubQueryError { reason: String },
+
+    #[error("Kaspa node error: {reason}")]
+    KaspaNodeError { reason: String },
 }

--- a/rust/main/chains/dymension-kaspa/src/validator_server.rs
+++ b/rust/main/chains/dymension-kaspa/src/validator_server.rs
@@ -146,8 +146,8 @@ async fn respond_validate_new_deposits<S: HyperlaneSignerExt + Send + Sync + 'st
     info!("Validator: checking new kaspa deposit");
     let deposits: DepositFXG = body.try_into().map_err(|e: eyre::Report| AppError(e))?;
     // Call to validator.G()
-    if resources.must_val_stuff().toggles.deposit_enabled
-        && !validate_new_deposit(
+    if resources.must_val_stuff().toggles.deposit_enabled {
+        validate_new_deposit(
             &resources.must_api(),
             resources.must_rest_client(),
             &deposits,
@@ -162,10 +162,7 @@ async fn respond_validate_new_deposits<S: HyperlaneSignerExt + Send + Sync + 'st
             ),
         )
         .await
-        .map_err(AppError)?
-    {
-        // TODO: return reasons and use them
-        return Err(AppError(eyre::eyre!("Validator G() function rejected")));
+        .map_err(|e| AppError(Report::from(e)))?;
     }
     info!(
         "Validator: deposit is valid: id = {:?}",


### PR DESCRIPTION
## Summary
- Updated deposit validation to use strongly typed `ValidationError` enum instead of generic eyre errors
- Updated confirmation validation to use `ValidationError` types consistently
- Modified validator_server.rs to handle the new error types properly

## Test plan
- [ ] Run existing tests for kaspa validator module
- [ ] Verify that deposit validation errors are properly categorized
- [ ] Verify that confirmation validation errors are properly categorized
- [ ] Ensure validator server correctly handles and reports validation errors

This change improves error handling consistency across all validation flows (deposit, withdrawal, and confirmation) by using the same strongly typed error enum throughout.

🤖 Generated with [Claude Code](https://claude.ai/code)