### PR TITLE
Fix memo token wiring issues in Solana client

### DIFF
--- a/rust/sealevel/client/src/main.rs
+++ b/rust/sealevel/client/src/main.rs
@@ -45,7 +45,10 @@ use hyperlane_sealevel_token::{
 use hyperlane_sealevel_token_collateral::{
     hyperlane_token_escrow_pda_seeds, plugin::CollateralPlugin,
 };
-use hyperlane_sealevel_token_collateral_memo::hyperlane_token_escrow_pda_seeds as hyperlane_token_escrow_pda_seeds_memo;
+use hyperlane_sealevel_token_collateral_memo::{
+    hyperlane_token_ata_payer_pda_seeds as hyperlane_token_ata_payer_pda_seeds_collateral_memo,
+    hyperlane_token_escrow_pda_seeds as hyperlane_token_escrow_pda_seeds_memo,
+};
 use hyperlane_sealevel_token_lib::{
     accounts::HyperlaneTokenAccount,
     hyperlane_token_pda_seeds,
@@ -1213,7 +1216,7 @@ fn process_token_cmd(mut ctx: Context, cmd: TokenCmd) {
                     );
 
                     let (ata_payer_account, ata_payer_bump) = Pubkey::find_program_address(
-                        hyperlane_token_ata_payer_pda_seeds!(),
+                        hyperlane_token_ata_payer_pda_seeds_collateral_memo!(),
                         &query.program_id,
                     );
 


### PR DESCRIPTION
- Add memo token types to fund_ata_payer checks
- Include SyntheticMemo in verify_config validation
- Import CollateralMemo ATA payer seeds
- Use correct mint PDA seeds for SyntheticMemo
- Pass token type to fund_ata_payer_up_to for proper PDA derivation

🤖 Generated with [Claude Code](https://claude.ai/code)

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
