### PR TITLE
Fix semantic misuse of signature_script field

### DIFF
--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
@@ -37,24 +37,25 @@ use tracing::info;
 pub async fn fetch_input_utxos(
     kaspa_rpc: &Arc<DynRpcApi>,
     address: &kaspa_addresses::Address,
-    signature_script: Vec<u8>,
+    redeem_script: Option<Vec<u8>>,
     sig_op_count: u8,
     network_id: NetworkId,
 ) -> Result<Vec<PopulatedInput>> {
     let utxos = get_utxo_to_spend(&address, kaspa_rpc, network_id).await?;
 
-    // Create a vector of "populated" inputs: TransactionInput and UtxoEntry.
+    // Create a vector of "populated" inputs: TransactionInput, UtxoEntry, and optional redeem_script.
     Ok(utxos
         .into_iter()
         .map(|utxo| {
             (
                 TransactionInput::new(
                     kaspa_consensus_core::tx::TransactionOutpoint::from(utxo.outpoint),
-                    signature_script.clone(),
-                    0, // sequence does not matter
+                    vec![], // signature_script is empty for unsigned transactions
+                    0,      // sequence does not matter
                     sig_op_count,
                 ),
                 UtxoEntry::from(utxo.utxo_entry),
+                redeem_script.clone(),
             )
         })
         .collect())
@@ -125,15 +126,18 @@ pub fn build_withdrawal_pskt(
     // in case of hyperinflation
 
     let (escrow_balance, relayer_balance) =
-        inputs.iter().fold((0, 0), |mut acc, (input, entry)| {
-            if input.signature_script.is_empty() {
-                // relayer has empty signature script
-                acc.1 += entry.amount;
-            } else {
-                acc.0 += entry.amount;
-            }
-            acc
-        });
+        inputs
+            .iter()
+            .fold((0, 0), |mut acc, (_input, entry, redeem_script)| {
+                if redeem_script.is_none() {
+                    // relayer has no redeem script
+                    acc.1 += entry.amount;
+                } else {
+                    // escrow has redeem script
+                    acc.0 += entry.amount;
+                }
+                acc
+            });
 
     let withdrawal_balance: u64 = outputs.iter().map(|w| w.value).sum();
 
@@ -241,7 +245,7 @@ fn create_withdrawal_pskt(
     let mut pskt = PSKT::<Creator>::default().constructor();
 
     // Add inputs
-    for (input, entry) in inputs.into_iter() {
+    for (input, entry, redeem_script) in inputs.into_iter() {
         let mut b = InputBuilder::default();
 
         b.utxo_entry(entry)
@@ -249,9 +253,9 @@ fn create_withdrawal_pskt(
             .sig_op_count(input.sig_op_count)
             .sighash_type(input_sighash_type());
 
-        if !input.signature_script.is_empty() {
+        if let Some(script) = redeem_script {
             // escrow inputs need redeem_script
-            b.redeem_script(input.signature_script);
+            b.redeem_script(script);
         }
 
         pskt = pskt.input(
@@ -348,7 +352,7 @@ pub(crate) fn extract_current_anchor(
 ) -> Result<(PopulatedInput, Vec<PopulatedInput>)> {
     let anchor_index = escrow_inputs
         .iter()
-        .position(|i| i.0.previous_outpoint == current_anchor)
+        .position(|(input, _, _)| input.previous_outpoint == current_anchor)
         .ok_or(eyre::eyre!(
             "Current anchor not found in escrow UTXO set: {current_anchor:?}"
         ))?; // Should always be found
@@ -368,10 +372,9 @@ fn estimate_mass(
     let (inputs, utxo_references): (Vec<_>, Vec<_>) = populated_inputs
         .into_iter()
         .map(|populated| {
-            (
-                populated.0.clone(),
-                utxo_reference_from_populated_input(populated),
-            )
+            let input = populated.0.clone();
+            let utxo_ref = utxo_reference_from_populated_input(populated);
+            (input, utxo_ref)
         })
         .unzip();
 

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
@@ -17,7 +17,8 @@ use kaspa_consensus_core::tx::{TransactionInput, TransactionOutpoint, UtxoEntry}
 use kaspa_wallet_pskt::bundle::Bundle;
 use tracing::info;
 
-pub(crate) type PopulatedInput = (TransactionInput, UtxoEntry);
+// (input, entry, optional_redeem_script)
+pub(crate) type PopulatedInput = (TransactionInput, UtxoEntry, Option<Vec<u8>>);
 
 /// Processes given messages and returns WithdrawFXG and the very first outpoint
 /// (the one preceding all the given transfers; it should be used during process indication).
@@ -74,7 +75,7 @@ pub async fn build_withdrawal_fxg(
     let escrow_inputs = fetch_input_utxos(
         &relayer.api(),
         &escrow_public.addr,
-        escrow_public.redeem_script.clone(),
+        Some(escrow_public.redeem_script.clone()),
         escrow_public.n() as u8,
         relayer.net.network_id,
     )
@@ -85,7 +86,7 @@ pub async fn build_withdrawal_fxg(
     let relayer_inputs = fetch_input_utxos(
         &relayer.api(),
         &relayer_address,
-        vec![],
+        None,
         RELAYER_SIG_OP_COUNT,
         relayer.net.network_id,
     )

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/sweep.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/sweep.rs
@@ -31,7 +31,7 @@ pub async fn create_sweeping_bundle(
     escrow_inputs: Vec<PopulatedInput>,
     relayer_inputs: Vec<PopulatedInput>,
 ) -> Result<Bundle> {
-    let sweep_balance = escrow_inputs.iter().map(|(_, e)| e.amount).sum::<u64>();
+    let sweep_balance = escrow_inputs.iter().map(|(_, e, _)| e.amount).sum::<u64>();
 
     let utxo_iterator = Box::new(
         escrow_inputs
@@ -156,7 +156,7 @@ pub fn create_inputs_from_sweeping_bundle(
     let relayer_input: PopulatedInput = (
         TransactionInput::new(
             TransactionOutpoint::new(tx_id, relayer_idx),
-            vec![],
+            vec![], // signature_script is empty for unsigned transactions
             u64::MAX,
             RELAYER_SIG_OP_COUNT,
         ),
@@ -166,12 +166,13 @@ pub fn create_inputs_from_sweeping_bundle(
             UNACCEPTED_DAA_SCORE,
             false,
         ),
+        None, // relayer has no redeem script
     );
 
     let escrow_input: PopulatedInput = (
         TransactionInput::new(
             TransactionOutpoint::new(tx_id, escrow_idx),
-            escrow.redeem_script.clone(),
+            vec![], // signature_script is empty for unsigned transactions
             u64::MAX,
             escrow.n() as u8,
         ),
@@ -181,13 +182,14 @@ pub fn create_inputs_from_sweeping_bundle(
             UNACCEPTED_DAA_SCORE,
             false,
         ),
+        Some(escrow.redeem_script.clone()), // escrow has redeem script
     );
 
     Ok(vec![relayer_input, escrow_input])
 }
 
 pub(crate) fn utxo_reference_from_populated_input(
-    (input, entry): PopulatedInput,
+    (input, entry, _redeem_script): PopulatedInput,
 ) -> UtxoEntryReference {
     UtxoEntryReference::from(ClientUtxoEntry {
         address: None,


### PR DESCRIPTION
## Summary

Fixes #227 by correcting the semantic misuse of the `signature_script` field in TransactionInput.

## Problem

The code was incorrectly storing the multisig redeem script in the `signature_script` field of `TransactionInput`. This is semantically wrong because:
- **Signature Script**: Should contain actual signatures for signed transactions
- **Redeem Script**: Defines the spending conditions (e.g., "2 of 3 multisig")

## Solution

The fix uses the simplest and most elegant approach:

1. **Extended PopulatedInput type**: Added an optional redeem_script as the third element of the tuple
   ```rust
   pub(crate) type PopulatedInput = (TransactionInput, UtxoEntry, Option<Vec<u8>>);
   ```

2. **Keep signature_script empty**: For unsigned transactions, the signature_script is always empty (as it should be)

3. **Store redeem_script separately**: The redeem script is stored in the tuple and only added to PSKT when building the transaction

## Changes

- Modified `fetch_input_utxos` to accept an optional redeem_script parameter and return the extended tuple
- Updated all code that uses PopulatedInput to handle the three-element tuple
- Fixed the logic that previously used `signature_script.is_empty()` to distinguish between escrow and relayer inputs
- Now uses `redeem_script.is_none()` for this distinction

## Testing

- ✅ Code compiles successfully
- ✅ Maintains the same functionality while being semantically correct
- The PSKT builder still correctly transfers the redeem script to the appropriate field

This fix prevents future confusion and potential bugs from the semantic mismatch.