### PR TITLE
fix: retry withdrawal msgs when failed Kaspa submission

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/mailbox.rs
+++ b/rust/main/chains/dymension-kaspa/src/mailbox.rs
@@ -1,3 +1,5 @@
+use std::os::unix::process;
+
 use super::consts::*;
 use crate::KaspaProvider;
 use dym_kas_relayer::withdraw::minimum::is_small_value;
@@ -9,7 +11,7 @@ use hyperlane_core::{
 use hyperlane_cosmos_rs::dymensionxyz::dymension::kas::{WithdrawalId, WithdrawalStatus};
 use hyperlane_warp_route::TokenMessage;
 use tonic::async_trait;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 // pretends to be a mailbox
 #[derive(Debug, Clone)]
@@ -138,10 +140,22 @@ impl Mailbox for KaspaMailbox {
             .map(|op| op.try_batch().map(|item| item.data)) // TODO: please work...
             .collect::<ChainResult<Vec<HyperlaneMessage>>>()?;
 
-        let processed_messages = self
+        let result_processed_messages = self
             .provider
             .process_withdrawal_messages(messages.clone())
-            .await?;
+            .await;
+
+        let processed_messages = match result_processed_messages {
+            Ok(messages) => {
+                info!("Kaspa mailbox, processed withdrawals TXs");
+                messages
+            }
+            Err(e) => {
+                error!("Kaspa mailbox, failed to process withdrawals TXs: {:?}", e);
+                Vec::new()
+            }
+        };
+
         info!("Kaspa mailbox, processed withdrawals TXs");
 
         // Note: this return value doesn't really correspond well to what we did, since we sent (possibly) multiple TXs to Kaspa

--- a/rust/main/chains/dymension-kaspa/src/mailbox.rs
+++ b/rust/main/chains/dymension-kaspa/src/mailbox.rs
@@ -9,7 +9,7 @@ use hyperlane_core::{
 use hyperlane_cosmos_rs::dymensionxyz::dymension::kas::{WithdrawalId, WithdrawalStatus};
 use hyperlane_warp_route::TokenMessage;
 use tonic::async_trait;
-use tracing::info;
+use tracing::{info, warn};
 
 // pretends to be a mailbox
 #[derive(Debug, Clone)]
@@ -155,6 +155,10 @@ impl Mailbox for KaspaMailbox {
                     failed.push(i);
                 }
             }
+            warn!(
+                "Kaspa mailbox, processed batch, failed indexes: {:?}",
+                failed
+            );
             failed
         };
 

--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -26,7 +26,6 @@ use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
 use kaspa_addresses::Address;
 use kaspa_rpc_core::model::{RpcTransaction, RpcTransactionId};
 use kaspa_wallet_core::prelude::DynRpcApi;
-use tracing::error;
 use std::sync::Arc;
 use tonic::async_trait;
 use tracing::info;

--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -191,15 +191,8 @@ impl KaspaProvider {
         )
         .await?;
 
-        match self.submit_txs(finalized.clone()).await {
-            Ok(_) => {
-                info!("Kaspa provider, submitted TXs, now indicating progress on the Hub");
-            }
-            Err(e) => {
-                error!("Kaspa provider, failed to submit TXs: {:?}", e);
-                return Ok(vec![]);
-            }
-        }
+        let _ = self.submit_txs(finalized.clone()).await?;
+        info!("Kaspa provider, submitted TXs, now indicating progress on the Hub");
 
         self.pending_confirmation
             .push(ConfirmationFXG::from_msgs_outpoints(fxg.ids(), fxg.anchors));

--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -26,6 +26,7 @@ use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
 use kaspa_addresses::Address;
 use kaspa_rpc_core::model::{RpcTransaction, RpcTransactionId};
 use kaspa_wallet_core::prelude::DynRpcApi;
+use tracing::error;
 use std::sync::Arc;
 use tonic::async_trait;
 use tracing::info;
@@ -190,8 +191,15 @@ impl KaspaProvider {
         )
         .await?;
 
-        let _ = self.submit_txs(finalized.clone()).await?;
-        info!("Kaspa provider, submitted TXs, now indicating progress on the Hub");
+        match self.submit_txs(finalized.clone()).await {
+            Ok(_) => {
+                info!("Kaspa provider, submitted TXs, now indicating progress on the Hub");
+            }
+            Err(e) => {
+                error!("Kaspa provider, failed to submit TXs: {:?}", e);
+                return Ok(vec![]);
+            }
+        }
 
         self.pending_confirmation
             .push(ConfirmationFXG::from_msgs_outpoints(fxg.ids(), fxg.anchors));


### PR DESCRIPTION
When it fails on submitting transactions to Kaspa, withdrawal flow fails without retrying because process_withdrawal_messages() fails instead of returning successful withdrawals ids. 
An error is logged but withdrawal is never retried and missed, unless restarting.
This PR changes this and when failing to submit it logs error and returns empty withdrawals ids, so it retries for the failed ids in next iteration. 