### PR TITLE
feat: limit withdrawal outputs based on max mass per tx

### DIFF
--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
@@ -4,7 +4,6 @@ use crate::withdraw::sweep::utxo_reference_from_populated_input;
 use corelib::escrow::EscrowPublic;
 use corelib::finality;
 use corelib::message::parse_hyperlane_metadata;
-use corelib::payload::MessageIDs;
 use corelib::util::{get_recipient_script_pubkey, input_sighash_type};
 use corelib::wallet::EasyKaspaWallet;
 use corelib::wallet::SigningResources;
@@ -26,7 +25,7 @@ use kaspa_rpc_core::{RpcTransaction, RpcUtxosByAddressesEntry};
 use kaspa_txscript::standard::pay_to_address_script;
 use kaspa_txscript::{opcodes::codes::OpData65, script_builder::ScriptBuilder};
 use kaspa_wallet_core::prelude::DynRpcApi;
-use kaspa_wallet_core::tx::{MassCalculator, MAXIMUM_STANDARD_TRANSACTION_MASS};
+use kaspa_wallet_core::tx::MassCalculator;
 use kaspa_wallet_pskt::prelude::Bundle;
 use kaspa_wallet_pskt::prelude::*;
 use kaspa_wallet_pskt::prelude::{Signer, PSKT};
@@ -110,9 +109,10 @@ pub fn build_withdrawal_pskt(
     payload: Vec<u8>,
     escrow: &EscrowPublic,
     relayer_addr: &kaspa_addresses::Address,
-    network_id: NetworkId,
+    _network_id: NetworkId,
     min_deposit_sompi: U256,
     feerate: f64,
+    tx_mass: u64,
 ) -> Result<PSKT<Signer>> {
     //////////////////
     //   Balances   //
@@ -159,15 +159,6 @@ pub fn build_withdrawal_pskt(
     //////////////////
     //     Fee      //
     //////////////////
-
-    let tx_mass = estimate_mass(
-        inputs.clone(),
-        outputs.clone(),
-        payload.clone(),
-        network_id,
-        escrow.m() as u16,
-    )
-    .map_err(|e| eyre::eyre!("Estimate TX mass: {e}"))?;
 
     // Apply TX mass multiplier and feerate
     let tx_fee = (tx_mass as f64 * feerate).round() as u64;

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
@@ -150,17 +150,66 @@ pub async fn build_withdrawal_fxg(
         (None, inputs)
     };
 
-    let payload = MessageIDs::from(&valid_msgs).to_bytes();
+    // Estimate mass and remove outputs if necessary
+    let mut final_outputs = outputs.clone();
+    let mut final_msgs = valid_msgs.clone();
+
+    // Calculate initial mass
+    let mut tx_mass = super::hub_to_kaspa::estimate_mass(
+        inputs.clone(),
+        final_outputs.clone(),
+        MessageIDs::from(&final_msgs).to_bytes(),
+        relayer.net.network_id,
+        escrow_public.m() as u16,
+    )
+    .map_err(|e| eyre::eyre!("Estimate TX mass: {e}"))?;
+
+    // Remove outputs from the end if mass exceeds maximum
+    let original_count = final_outputs.len();
+    while tx_mass > kaspa_wallet_core::tx::MAXIMUM_STANDARD_TRANSACTION_MASS && !final_outputs.is_empty() {
+        final_outputs.pop();
+        final_msgs.pop();
+
+        // Recalculate mass with reduced outputs
+        if !final_outputs.is_empty() {
+            tx_mass = super::hub_to_kaspa::estimate_mass(
+                inputs.clone(),
+                final_outputs.clone(),
+                MessageIDs::from(&final_msgs).to_bytes(),
+                relayer.net.network_id,
+                escrow_public.m() as u16,
+            )
+            .map_err(|e| eyre::eyre!("Estimate TX mass after output removal: {e}"))?;
+        }
+    }
+
+    if final_outputs.len() < original_count {
+        info!(
+            "Kaspa relayer, reduced withdrawals from {} to {} due to mass limit. Final mass: {}",
+            original_count,
+            final_outputs.len(),
+            tx_mass
+        );
+    }
+
+    if final_outputs.is_empty() {
+        return Err(eyre::eyre!(
+            "Cannot process any withdrawals - even a single withdrawal exceeds mass limit"
+        ));
+    }
+
+    let payload = MessageIDs::from(&final_msgs).to_bytes();
 
     let pskt = build_withdrawal_pskt(
         inputs,
-        outputs,
+        final_outputs,
         payload,
         &escrow_public,
         &relayer_address,
         relayer.net.network_id,
         min_deposit_sompi,
         feerate*tx_fee_multiplier,
+        tx_mass,
     )
     .map_err(|e| eyre::eyre!("Build withdrawal PSKT: {}", e))?;
 
@@ -171,9 +220,9 @@ pub async fn build_withdrawal_fxg(
     // The last element is the withdrawal PSKT, so it should have all the HL messages.
     let messages = {
         let sweep_count = sweeping_bundle.as_ref().map_or(0, |b| b.0.len());
-        let mut messages = Vec::with_capacity(sweep_count + valid_msgs.len());
+        let mut messages = Vec::with_capacity(sweep_count + final_msgs.len());
         messages.extend(vec![Vec::new(); sweep_count]);
-        messages.push(valid_msgs);
+        messages.push(final_msgs);
         messages
     };
 


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
