### PR TITLE
feat: add ability to create validator key in aws secret manager backend

### DIFF
--- a/dymension/libs/kaspa/Cargo.lock
+++ b/dymension/libs/kaspa/Cargo.lock
@@ -2629,6 +2629,10 @@ dependencies = [
 name = "demo-user"
 version = "0.1.0"
 dependencies = [
+ "aws-config",
+ "aws-sdk-kms",
+ "aws-sdk-secretsmanager",
+ "aws-smithy-types",
  "chrono",
  "clap",
  "cometbft",

--- a/dymension/libs/kaspa/demo/user/Cargo.toml
+++ b/dymension/libs/kaspa/demo/user/Cargo.toml
@@ -47,3 +47,7 @@ thiserror = "2.0"
 cosmos-sdk-proto = { version = "0.26.1" }
 cometbft = { workspace = true, features = ["secp256k1"] }
 cometbft-rpc = { workspace = true, features = ["http-client","secp256k1"] }
+aws-config = { version = "1.5", features = ["behavior-version-latest"] }
+aws-sdk-secretsmanager = "1.55"
+aws-sdk-kms = "1.48"
+aws-smithy-types = "1.2"

--- a/dymension/libs/kaspa/demo/user/src/main.rs
+++ b/dymension/libs/kaspa/demo/user/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use x::args::{Cli, Commands};
+use x::args::{Cli, Commands, ValidatorAction, ValidatorBackend};
 
 mod sim;
 use sim::{SimulateTrafficArgs, TrafficSim};
@@ -27,16 +27,23 @@ async fn run(cli: Cli) {
             let e = x::escrow::get_escrow_address(pub_keys, args.required_signatures);
             println!("Escrow address: {e}");
         }
-        Commands::Validator(args) => {
-            let mut infos = vec![];
-            for _ in 0..args.n {
-                let (v, _) = x::escrow::create_validator();
-                infos.push(v);
-            }
-            // sort required by Hyperlane Cosmos ISM creation
-            infos.sort_by(|a, b| a.validator_ism_addr.cmp(&b.validator_ism_addr));
-            println!("{}", serde_json::to_string_pretty(&infos).unwrap());
+        Commands::Validator { action } => match action {
+            ValidatorAction::Create { backend } => match backend {
+                ValidatorBackend::Local(args) => {
+                    if let Err(e) = x::validator::handle_local_backend(args) {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+                ValidatorBackend::Aws(args) => {
+                    if let Err(e) = x::validator::handle_aws_backend(args).await {
+                        eprintln!("Error: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            },
         }
+
         Commands::ValidatorAndEscrow => {
             let v = x::escrow::create_validator_with_escrow();
             println!("Validator infos: {}", v.to_string());

--- a/dymension/libs/kaspa/demo/user/src/main.rs
+++ b/dymension/libs/kaspa/demo/user/src/main.rs
@@ -42,12 +42,7 @@ async fn run(cli: Cli) {
                     }
                 }
             },
-        }
-
-        Commands::ValidatorAndEscrow => {
-            let v = x::escrow::create_validator_with_escrow();
-            println!("Validator infos: {}", v.to_string());
-        }
+        },
         Commands::Relayer => {
             let signer = x::relayer::create_relayer();
             println!("Relayer address: {}", signer.address);

--- a/dymension/libs/kaspa/demo/user/src/x/args.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/args.rs
@@ -29,9 +29,6 @@ pub enum Commands {
         #[command(subcommand)]
         action: ValidatorAction,
     },
-    /// Generate all the info needed for a validator with a 1 of 1 multisig escrow
-    #[clap(name = "validator-with-escrow")]
-    ValidatorAndEscrow,
     /// Make a user deposit (to escrow)
     Deposit(DepositCli),
     /// Create a relayer

--- a/dymension/libs/kaspa/demo/user/src/x/args.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/args.rs
@@ -24,8 +24,11 @@ pub enum Commands {
     Recipient(RecipientCli),
     /// Get the escrow address for some secp256k1 pub keys (like kaspatest:pzlq49spp6...66ne90v7e6pyrfr)
     Escrow(EscrowCli),
-    /// Generate all the info needed for a validator (without escrow address)
-    Validator(ValidatorCli),
+    /// Validator management commands
+    Validator {
+        #[command(subcommand)]
+        action: ValidatorAction,
+    },
     /// Generate all the info needed for a validator with a 1 of 1 multisig escrow
     #[clap(name = "validator-with-escrow")]
     ValidatorAndEscrow,
@@ -38,11 +41,45 @@ pub enum Commands {
     SimulateTraffic(SimulateTrafficCli),
 }
 
+#[derive(Subcommand, Debug)]
+pub enum ValidatorAction {
+    /// Create new validator keys
+    Create {
+        #[command(subcommand)]
+        backend: ValidatorBackend,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum ValidatorBackend {
+    /// Generate and store validator keys locally
+    Local(ValidatorLocalArgs),
+
+    /// Generate and store validator keys in AWS Secrets Manager
+    Aws(ValidatorAwsArgs),
+}
+
 #[derive(Args, Debug)]
-pub struct ValidatorCli {
-    /// Generate more than one validator at a time
-    #[arg(required = false, index = 1, default_value = "1")]
-    pub n: u32,
+pub struct ValidatorLocalArgs {
+    /// Number of validators to generate
+    #[arg(short = 'n', long, default_value = "1")]
+    pub count: u32,
+
+    /// Optional: save output to JSON file
+    #[arg(short, long)]
+    pub output: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct ValidatorAwsArgs {
+    /// Secret path for storing the validator keys (e.g., /hyperlane/kaspa/validator-1)
+    /// All validator key properties will be stored as an encrypted JSON object at this path
+    #[arg(short, long)]
+    pub path: String,
+
+    /// AWS KMS symmetric key ID or ARN for encryption (must be SYMMETRIC_DEFAULT, not RSA/ECC)
+    #[arg(long)]
+    pub kms_key_id: String,
 }
 
 #[derive(Args, Debug)]

--- a/dymension/libs/kaspa/demo/user/src/x/escrow.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/escrow.rs
@@ -1,10 +1,7 @@
 use corelib::escrow::EscrowPublic;
 use kaspa_addresses::Prefix;
 use secp256k1::PublicKey;
-use serde::Serialize;
 use std::str::FromStr;
-
-use super::validator;
 
 pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8) -> String {
     let pub_keys = pub_keys
@@ -13,38 +10,4 @@ pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8) -> Strin
         .collect::<Vec<_>>();
     let e = EscrowPublic::from_pubs(pub_keys, Prefix::Testnet, required_signatures);
     e.addr.to_string()
-}
-
-#[derive(Debug, Serialize)]
-pub struct ValidatorInfosWithEscrow {
-    // HL style address to register on the Hub for the Kaspa multisig ISM
-    pub validator_ism_addr: String,
-    /// what validator will use to sign checkpoints for new deposits (and also progress indications)
-    validator_ism_priv_key: String,
-    /// secret key to sign kaspa inputs for withdrawals
-    validator_escrow_secret: String,
-    /// and pub key...
-    validator_escrow_pub_key: String,
-    /// the address the bridge end user should deposit to
-    multisig_escrow_addr: String,
-}
-
-impl ValidatorInfosWithEscrow {
-    pub fn to_string(&self) -> String {
-        serde_json::to_string_pretty(self).unwrap()
-    }
-}
-
-pub fn create_validator_with_escrow() -> ValidatorInfosWithEscrow {
-    let (v, pub_key) = validator::create_validator();
-
-    let e = EscrowPublic::from_pubs(vec![pub_key], Prefix::Testnet, 1);
-
-    ValidatorInfosWithEscrow {
-        validator_ism_addr: v.validator_ism_addr,
-        validator_ism_priv_key: v.validator_ism_priv_key,
-        validator_escrow_secret: v.validator_escrow_secret,
-        validator_escrow_pub_key: v.validator_escrow_pub_key,
-        multisig_escrow_addr: e.addr.to_string(),
-    }
 }

--- a/dymension/libs/kaspa/demo/user/src/x/escrow.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/escrow.rs
@@ -1,10 +1,10 @@
-use corelib::escrow::generate_escrow_priv_key;
 use corelib::escrow::EscrowPublic;
 use kaspa_addresses::Prefix;
 use secp256k1::PublicKey;
 use serde::Serialize;
 use std::str::FromStr;
-use validator::signer::get_ethereum_style_signer;
+
+use super::validator;
 
 pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8) -> String {
     let pub_keys = pub_keys
@@ -16,7 +16,7 @@ pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8) -> Strin
 }
 
 #[derive(Debug, Serialize)]
-pub struct ValidatorInfos {
+pub struct ValidatorInfosWithEscrow {
     // HL style address to register on the Hub for the Kaspa multisig ISM
     pub validator_ism_addr: String,
     /// what validator will use to sign checkpoints for new deposits (and also progress indications)
@@ -26,41 +26,25 @@ pub struct ValidatorInfos {
     /// and pub key...
     validator_escrow_pub_key: String,
     /// the address the bridge end user should deposit to
-    multisig_escrow_addr: Option<String>,
+    multisig_escrow_addr: String,
 }
 
-impl ValidatorInfos {
+impl ValidatorInfosWithEscrow {
     pub fn to_string(&self) -> String {
         serde_json::to_string_pretty(self).unwrap()
     }
 }
 
-pub fn create_validator() -> (ValidatorInfos, PublicKey) {
-    let kp = generate_escrow_priv_key();
-    let s = serde_json::to_string(&kp).unwrap();
-
-    let signer = get_ethereum_style_signer().unwrap();
-    let pub_key = kp.public_key();
-
-    let ism_unescaped = signer.address.replace("\"", "");
-
-    (
-        ValidatorInfos {
-            validator_ism_addr: ism_unescaped,
-            validator_ism_priv_key: signer.private_key,
-            validator_escrow_secret: s,
-            validator_escrow_pub_key: pub_key.to_string(),
-            multisig_escrow_addr: None,
-        },
-        pub_key,
-    )
-}
-
-pub fn create_validator_with_escrow() -> ValidatorInfos {
-    let (mut v, pub_key) = create_validator();
+pub fn create_validator_with_escrow() -> ValidatorInfosWithEscrow {
+    let (v, pub_key) = validator::create_validator();
 
     let e = EscrowPublic::from_pubs(vec![pub_key], Prefix::Testnet, 1);
 
-    v.multisig_escrow_addr = Some(e.addr.to_string());
-    v
+    ValidatorInfosWithEscrow {
+        validator_ism_addr: v.validator_ism_addr,
+        validator_ism_priv_key: v.validator_ism_priv_key,
+        validator_escrow_secret: v.validator_escrow_secret,
+        validator_escrow_pub_key: v.validator_escrow_pub_key,
+        multisig_escrow_addr: e.addr.to_string(),
+    }
 }

--- a/dymension/libs/kaspa/demo/user/src/x/mod.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/mod.rs
@@ -3,3 +3,4 @@ pub mod args;
 pub mod deposit;
 pub mod escrow;
 pub mod relayer;
+pub mod validator;

--- a/dymension/libs/kaspa/demo/user/src/x/validator.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/validator.rs
@@ -18,12 +18,6 @@ pub struct ValidatorInfos {
     pub validator_escrow_pub_key: String,
 }
 
-impl ValidatorInfos {
-    pub fn to_string(&self) -> String {
-        serde_json::to_string_pretty(self).unwrap()
-    }
-}
-
 pub fn create_validator() -> (ValidatorInfos, PublicKey) {
     let kp = generate_escrow_priv_key();
     let s = serde_json::to_string(&kp).unwrap();
@@ -83,9 +77,7 @@ pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn st
     let (validator_info, _) = create_validator();
 
     // Initialize AWS SDK
-    let config = aws_config::defaults(BehaviorVersion::latest())
-        .load()
-        .await;
+    let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
 
     let kms_client = KmsClient::new(&config);
     let sm_client = SecretsManagerClient::new(&config);
@@ -100,7 +92,10 @@ pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn st
     println!();
     println!("Validator info:");
     println!("  ISM Address: {}", validator_info.validator_ism_addr);
-    println!("  Escrow Pub Key: {}", validator_info.validator_escrow_pub_key);
+    println!(
+        "  Escrow Pub Key: {}",
+        validator_info.validator_escrow_pub_key
+    );
     println!();
 
     // Serialize the entire validator info to JSON
@@ -112,12 +107,8 @@ pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn st
 
     // Store the encrypted JSON in Secrets Manager
     println!("Storing encrypted validator keys at: {}", secret_path);
-    let secret_arn = store_encrypted_secret(
-        &sm_client,
-        secret_path,
-        encrypted_json,
-        "validator keys"
-    ).await?;
+    let secret_arn =
+        store_encrypted_secret(&sm_client, secret_path, encrypted_json, "validator keys").await?;
 
     println!();
     println!("✓ Successfully created validator secret!");
@@ -139,7 +130,8 @@ async fn validate_kms_key(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match kms_client.describe_key().key_id(key_id).send().await {
         Ok(response) => {
-            let key_metadata = response.key_metadata()
+            let key_metadata = response
+                .key_metadata()
                 .ok_or("KMS key metadata not found")?;
 
             // Check if key is enabled
@@ -147,7 +139,8 @@ async fn validate_kms_key(
                 return Err(format!(
                     "KMS key '{}' exists but is not enabled. Please enable it first.",
                     key_id
-                ).into());
+                )
+                .into());
             }
 
             // AWS Secrets Manager only supports symmetric KMS keys for encryption
@@ -178,14 +171,13 @@ async fn validate_kms_key(
 
             Ok(())
         }
-        Err(e) => {
-            Err(format!(
-                "KMS key '{}' not found or not accessible: {}.\n\
+        Err(e) => Err(format!(
+            "KMS key '{}' not found or not accessible: {}.\n\
                 Please create a symmetric KMS key first:\n\
                   aws kms create-key --description \"Hyperlane Validator Keys\"",
-                key_id, e
-            ).into())
-        }
+            key_id, e
+        )
+        .into()),
     }
 }
 
@@ -213,13 +205,12 @@ async fn encrypt_with_kms(
             // Return the binary ciphertext directly (no base64 encoding needed)
             Ok(ciphertext_blob.clone())
         }
-        Err(e) => {
-            Err(format!(
-                "Failed to encrypt with KMS key '{}': {}.\n\
+        Err(e) => Err(format!(
+            "Failed to encrypt with KMS key '{}': {}.\n\
                 Please check your KMS permissions (kms:Encrypt).",
-                key_id, e
-            ).into())
-        }
+            key_id, e
+        )
+        .into()),
     }
 }
 
@@ -239,9 +230,7 @@ async fn store_encrypted_secret(
         .send()
         .await
     {
-        Ok(response) => {
-            Ok(response.arn().unwrap_or("unknown").to_string())
-        }
+        Ok(response) => Ok(response.arn().unwrap_or("unknown").to_string()),
         Err(e) => {
             // Check if secret already exists
             let service_err = e.into_service_error();

--- a/dymension/libs/kaspa/demo/user/src/x/validator.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/validator.rs
@@ -69,8 +69,8 @@ pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn st
     use aws_sdk_kms::Client as KmsClient;
     use aws_sdk_secretsmanager::Client as SecretsManagerClient;
 
-    // Generate a single validator
-    let (validator_info, _) = create_validator();
+    let kaspa_keypair = generate_escrow_priv_key();
+    let kaspa_pub_key = kaspa_keypair.public_key();
 
     // Initialize AWS SDK
     let config = aws_config::defaults(BehaviorVersion::latest()).load().await;
@@ -84,37 +84,22 @@ pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn st
     // Normalize the path (remove trailing slash if present)
     let secret_path = args.path.trim_end_matches('/');
 
-    println!("Generating validator keys...");
-    println!();
-    println!("Validator info:");
-    println!(
-        "  Escrow Pub Key: {}",
-        validator_info.validator_escrow_pub_key
-    );
-    println!();
+    // Serialize ONLY the Kaspa keypair to JSON
+    // This is compatible with KaspaSecpKeypair deserialization in the validator agent
+    // The secp256k1 crate with serde serializes Keypair as a hex string of the secret key
+    let keypair_json = serde_json::to_string(&kaspa_keypair)?;
 
-    // Serialize the entire validator info to JSON
-    let json_plaintext = serde_json::to_string_pretty(&validator_info)?;
-
-    // Encrypt the entire JSON with KMS
-    println!("Encrypting validator keys with KMS...");
-    let encrypted_json = encrypt_with_kms(&kms_client, &args.kms_key_id, &json_plaintext).await?;
-
-    // Store the encrypted JSON in Secrets Manager
-    println!("Storing encrypted validator keys at: {}", secret_path);
+    let encrypted_keypair = encrypt_with_kms(&kms_client, &args.kms_key_id, &keypair_json).await?;
     let secret_arn =
         store_encrypted_secret(&sm_client, secret_path, encrypted_json, "validator keys").await?;
 
     println!();
-    println!("✓ Successfully created validator secret!");
+    println!("✓ Successfully created Kaspa validator secret!");
     println!();
     println!("Secret ARN: {}", secret_arn);
     println!("Secret ID: {}", secret_path);
-    println!("KMS Key: {}", args.kms_key_id);
-    println!();
-    println!("To retrieve and decrypt the secret:");
-    println!("  aws secretsmanager get-secret-value --secret-id {} --query SecretBinary --output text | base64 -d > ciphertext.bin", secret_path);
-    println!("  aws kms decrypt --ciphertext-blob fileb://ciphertext.bin --query Plaintext --output text | base64 -d");
+    println!("KMS Key ID: {}", args.kms_key_id);
+    println!("Kaspa Escrow Public Key: {}", kaspa_pub_key.to_string());
 
     Ok(())
 }

--- a/dymension/libs/kaspa/demo/user/src/x/validator.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/validator.rs
@@ -41,7 +41,6 @@ pub fn create_validator() -> (ValidatorInfos, PublicKey) {
 pub fn handle_local_backend(args: ValidatorLocalArgs) -> Result<(), Box<dyn std::error::Error>> {
     let mut infos = vec![];
 
-    // Generate validators
     for _ in 0..args.count {
         let (v, _) = create_validator();
         infos.push(v);
@@ -54,12 +53,10 @@ pub fn handle_local_backend(args: ValidatorLocalArgs) -> Result<(), Box<dyn std:
 
     match args.output {
         Some(path) => {
-            // Write to file
             fs::write(&path, json_output)?;
             println!("Validator keys saved to: {}", path);
         }
         None => {
-            // Print to stdout
             println!("{}", json_output);
         }
     }
@@ -68,7 +65,6 @@ pub fn handle_local_backend(args: ValidatorLocalArgs) -> Result<(), Box<dyn std:
 }
 
 pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn std::error::Error>> {
-    // Import AWS modules
     use aws_config::BehaviorVersion;
     use aws_sdk_kms::Client as KmsClient;
     use aws_sdk_secretsmanager::Client as SecretsManagerClient;
@@ -91,7 +87,6 @@ pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn st
     println!("Generating validator keys...");
     println!();
     println!("Validator info:");
-    println!("  ISM Address: {}", validator_info.validator_ism_addr);
     println!(
         "  Escrow Pub Key: {}",
         validator_info.validator_escrow_pub_key

--- a/dymension/libs/kaspa/demo/user/src/x/validator.rs
+++ b/dymension/libs/kaspa/demo/user/src/x/validator.rs
@@ -1,0 +1,262 @@
+use corelib::escrow::generate_escrow_priv_key;
+use secp256k1::PublicKey;
+use serde::Serialize;
+use std::fs;
+use validator::signer::get_ethereum_style_signer;
+
+use super::args::{ValidatorAwsArgs, ValidatorLocalArgs};
+
+#[derive(Debug, Serialize)]
+pub struct ValidatorInfos {
+    // HL style address to register on the Hub for the Kaspa multisig ISM
+    pub validator_ism_addr: String,
+    /// what validator will use to sign checkpoints for new deposits (and also progress indications)
+    pub validator_ism_priv_key: String,
+    /// secret key to sign kaspa inputs for withdrawals
+    pub validator_escrow_secret: String,
+    /// and pub key...
+    pub validator_escrow_pub_key: String,
+}
+
+impl ValidatorInfos {
+    pub fn to_string(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap()
+    }
+}
+
+pub fn create_validator() -> (ValidatorInfos, PublicKey) {
+    let kp = generate_escrow_priv_key();
+    let s = serde_json::to_string(&kp).unwrap();
+
+    let signer = get_ethereum_style_signer().unwrap();
+    let pub_key = kp.public_key();
+
+    let ism_unescaped = signer.address.replace("\"", "");
+
+    (
+        ValidatorInfos {
+            validator_ism_addr: ism_unescaped,
+            validator_ism_priv_key: signer.private_key,
+            validator_escrow_secret: s,
+            validator_escrow_pub_key: pub_key.to_string(),
+        },
+        pub_key,
+    )
+}
+
+pub fn handle_local_backend(args: ValidatorLocalArgs) -> Result<(), Box<dyn std::error::Error>> {
+    let mut infos = vec![];
+
+    // Generate validators
+    for _ in 0..args.count {
+        let (v, _) = create_validator();
+        infos.push(v);
+    }
+
+    // Sort required by Hyperlane Cosmos ISM creation
+    infos.sort_by(|a, b| a.validator_ism_addr.cmp(&b.validator_ism_addr));
+
+    let json_output = serde_json::to_string_pretty(&infos)?;
+
+    match args.output {
+        Some(path) => {
+            // Write to file
+            fs::write(&path, json_output)?;
+            println!("Validator keys saved to: {}", path);
+        }
+        None => {
+            // Print to stdout
+            println!("{}", json_output);
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn handle_aws_backend(args: ValidatorAwsArgs) -> Result<(), Box<dyn std::error::Error>> {
+    // Import AWS modules
+    use aws_config::BehaviorVersion;
+    use aws_sdk_kms::Client as KmsClient;
+    use aws_sdk_secretsmanager::Client as SecretsManagerClient;
+
+    // Generate a single validator
+    let (validator_info, _) = create_validator();
+
+    // Initialize AWS SDK
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .load()
+        .await;
+
+    let kms_client = KmsClient::new(&config);
+    let sm_client = SecretsManagerClient::new(&config);
+
+    // Validate KMS key exists and is usable
+    validate_kms_key(&kms_client, &args.kms_key_id).await?;
+
+    // Normalize the path (remove trailing slash if present)
+    let secret_path = args.path.trim_end_matches('/');
+
+    println!("Generating validator keys...");
+    println!();
+    println!("Validator info:");
+    println!("  ISM Address: {}", validator_info.validator_ism_addr);
+    println!("  Escrow Pub Key: {}", validator_info.validator_escrow_pub_key);
+    println!();
+
+    // Serialize the entire validator info to JSON
+    let json_plaintext = serde_json::to_string_pretty(&validator_info)?;
+
+    // Encrypt the entire JSON with KMS
+    println!("Encrypting validator keys with KMS...");
+    let encrypted_json = encrypt_with_kms(&kms_client, &args.kms_key_id, &json_plaintext).await?;
+
+    // Store the encrypted JSON in Secrets Manager
+    println!("Storing encrypted validator keys at: {}", secret_path);
+    let secret_arn = store_encrypted_secret(
+        &sm_client,
+        secret_path,
+        encrypted_json,
+        "validator keys"
+    ).await?;
+
+    println!();
+    println!("✓ Successfully created validator secret!");
+    println!();
+    println!("Secret ARN: {}", secret_arn);
+    println!("Secret ID: {}", secret_path);
+    println!("KMS Key: {}", args.kms_key_id);
+    println!();
+    println!("To retrieve and decrypt the secret:");
+    println!("  aws secretsmanager get-secret-value --secret-id {} --query SecretBinary --output text | base64 -d > ciphertext.bin", secret_path);
+    println!("  aws kms decrypt --ciphertext-blob fileb://ciphertext.bin --query Plaintext --output text | base64 -d");
+
+    Ok(())
+}
+
+async fn validate_kms_key(
+    kms_client: &aws_sdk_kms::Client,
+    key_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    match kms_client.describe_key().key_id(key_id).send().await {
+        Ok(response) => {
+            let key_metadata = response.key_metadata()
+                .ok_or("KMS key metadata not found")?;
+
+            // Check if key is enabled
+            if !key_metadata.enabled() {
+                return Err(format!(
+                    "KMS key '{}' exists but is not enabled. Please enable it first.",
+                    key_id
+                ).into());
+            }
+
+            // AWS Secrets Manager only supports symmetric KMS keys for encryption
+            // Check if the key is symmetric (ENCRYPT_DECRYPT usage)
+            if let Some(key_usage) = key_metadata.key_usage() {
+                if key_usage.as_str() != "ENCRYPT_DECRYPT" {
+                    return Err(format!(
+                        "KMS key '{}' has key usage '{}' but AWS Secrets Manager requires a symmetric key with ENCRYPT_DECRYPT usage.\n\
+                        Please create a symmetric encryption key:\n\
+                          aws kms create-key --description \"Hyperlane Validator Keys\" --key-usage ENCRYPT_DECRYPT",
+                        key_id, key_usage.as_str()
+                    ).into());
+                }
+            }
+
+            // Verify it's a symmetric key (not RSA or ECC)
+            if let Some(key_spec) = key_metadata.key_spec() {
+                if !key_spec.as_str().starts_with("SYMMETRIC") {
+                    return Err(format!(
+                        "KMS key '{}' has key spec '{}' but AWS Secrets Manager requires a symmetric key (SYMMETRIC_DEFAULT).\n\
+                        Asymmetric keys (RSA, ECC) cannot be used for Secrets Manager encryption.\n\
+                        Please create a symmetric encryption key:\n\
+                          aws kms create-key --description \"Hyperlane Validator Keys\"",
+                        key_id, key_spec.as_str()
+                    ).into());
+                }
+            }
+
+            Ok(())
+        }
+        Err(e) => {
+            Err(format!(
+                "KMS key '{}' not found or not accessible: {}.\n\
+                Please create a symmetric KMS key first:\n\
+                  aws kms create-key --description \"Hyperlane Validator Keys\"",
+                key_id, e
+            ).into())
+        }
+    }
+}
+
+async fn encrypt_with_kms(
+    kms_client: &aws_sdk_kms::Client,
+    key_id: &str,
+    plaintext: &str,
+) -> Result<aws_smithy_types::Blob, Box<dyn std::error::Error>> {
+    use aws_smithy_types::Blob;
+
+    let plaintext_blob = Blob::new(plaintext.as_bytes());
+
+    match kms_client
+        .encrypt()
+        .key_id(key_id)
+        .plaintext(plaintext_blob)
+        .send()
+        .await
+    {
+        Ok(response) => {
+            let ciphertext_blob = response
+                .ciphertext_blob()
+                .ok_or("KMS encrypt response missing ciphertext")?;
+
+            // Return the binary ciphertext directly (no base64 encoding needed)
+            Ok(ciphertext_blob.clone())
+        }
+        Err(e) => {
+            Err(format!(
+                "Failed to encrypt with KMS key '{}': {}.\n\
+                Please check your KMS permissions (kms:Encrypt).",
+                key_id, e
+            ).into())
+        }
+    }
+}
+
+async fn store_encrypted_secret(
+    sm_client: &aws_sdk_secretsmanager::Client,
+    path: &str,
+    encrypted_value: aws_smithy_types::Blob,
+    property_name: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Store the encrypted value as binary (raw KMS ciphertext)
+    // We do NOT specify kms_key_id here because we've already encrypted the value ourselves
+    match sm_client
+        .create_secret()
+        .name(path)
+        .secret_binary(encrypted_value)
+        .description(format!("Hyperlane Kaspa validator key: {}", property_name))
+        .send()
+        .await
+    {
+        Ok(response) => {
+            Ok(response.arn().unwrap_or("unknown").to_string())
+        }
+        Err(e) => {
+            // Check if secret already exists
+            let service_err = e.into_service_error();
+            if service_err.is_resource_exists_exception() {
+                Err(format!(
+                    "Secret '{}' already exists. Please choose a different base path or delete existing secrets:\n\
+                      aws secretsmanager delete-secret --secret-id {} --force-delete-without-recovery",
+                    path, path
+                ).into())
+            } else {
+                Err(format!(
+                    "Failed to create secret '{}': {}. Please check your AWS credentials and permissions.",
+                    path, service_err
+                ).into())
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description

extends the validator command with 2 backends:

```
cargo run validator create aws --path /hyperlane/kaspa/test-key-1 \
--kms-key-id arn:aws:kms:eu-central-1:119065360830:key/55a8e6b4-cde9-4601-a5f3-f3ceb0c3ec01

 cargo run validator create local
```

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
