### PR TITLE
fix(solidity): apply CEI pattern to memo contracts

### DIFF
--- a/solidity/contracts/token/extensions/HypERC20CollateralMemo.sol
+++ b/solidity/contracts/token/extensions/HypERC20CollateralMemo.sol
@@ -28,9 +28,13 @@ contract HypERC20CollateralMemo is HypERC20Collateral {
     function _transferFromSender(
         uint256 _amount
     ) internal virtual override returns (bytes memory) {
-        super._transferFromSender(_amount);
+        // Follow CEI pattern: read and clear _memo BEFORE external call
+        // to prevent reentrancy if wrappedToken has callbacks (ERC777, custom hooks)
         bytes memory memo = _memo;
         delete _memo;
+
+        super._transferFromSender(_amount);
+
         emit IncludedMemo(memo);
         return memo;
     }

--- a/solidity/contracts/token/extensions/HypERC20Memo.sol
+++ b/solidity/contracts/token/extensions/HypERC20Memo.sol
@@ -28,9 +28,13 @@ contract HypERC20Memo is HypERC20 {
     function _transferFromSender(
         uint256 _amount
     ) internal virtual override returns (bytes memory) {
-        super._transferFromSender(_amount);
+        // Follow CEI pattern: read and clear _memo BEFORE burn
+        // to prevent reentrancy if child contracts override token hooks with external calls
         bytes memory memo = _memo;
         delete _memo;
+
+        super._transferFromSender(_amount);
+
         emit IncludedMemo(memo);
         return memo;
     }


### PR DESCRIPTION
## Summary
Fixes reentrancy vulnerabilities in HypERC20CollateralMemo and HypERC20Memo by applying the Checks-Effects-Interactions (CEI) pattern.

## Changes
- **HypERC20CollateralMemo**: Move memo read/delete before `safeTransferFrom()` external call
- **HypERC20Memo**: Move memo read/delete before `_burn()` call
- Add security comments explaining the CEI pattern and why it's necessary

## Security Context
The vulnerability is conditional - only exploitable when:
- Wrapped tokens have callbacks (ERC777, custom hooks)
- Malicious or compromised token contracts
- Upgradeable proxies that could add hooks later

With standard ERC20 tokens (USDC, WETH, DAI), the vulnerability is not exploitable. However, applying the CEI pattern is defense-in-depth and prevents future misuse.

## Testing
- ✅ Prettier formatting applied
- ✅ No linting errors
- ✅ Changes preserve existing functionality

Resolves dymensionxyz/hyperlane-deployments#85

🤖 Generated with [Claude Code](https://claude.com/claude-code)