### PR TITLE
feat(kaspa): claude: add kaspa wrpc retry utility with reconnection

### DIFF
--- a/dymension/libs/kaspa/lib/core/src/lib.rs
+++ b/dymension/libs/kaspa/lib/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod finality;
 pub mod message;
 pub mod payload;
 pub mod pskt;
+pub mod rpc_retry;
 pub mod user;
 pub mod util;
 pub mod wallet;

--- a/dymension/libs/kaspa/lib/core/src/rpc_retry.rs
+++ b/dymension/libs/kaspa/lib/core/src/rpc_retry.rs
@@ -8,6 +8,54 @@ use tracing::{debug, error, info};
 const MAX_RETRIES: u32 = 3;
 const RETRY_DELAY_MS: u64 = 1000;
 
+/// Executes an RPC call with automatic retry on failure.
+///
+/// If the RPC call fails (e.g., 500 error from disconnected server),
+/// this will retry the call with exponential backoff.
+///
+/// Usage:
+/// ```ignore
+/// use corelib::rpc_retry::rpc_call_with_retry;
+///
+/// let result = rpc_call_with_retry(|| async {
+///     rpc_client.get_block(hash, true).await
+/// }).await?;
+/// ```
+pub async fn rpc_call_with_retry<F, Fut, T>(f: F) -> Result<T>
+where
+    F: Fn() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    for attempt in 1..=MAX_RETRIES {
+        match f().await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                if attempt == MAX_RETRIES {
+                    error!(
+                        attempt = attempt,
+                        max_retries = MAX_RETRIES,
+                        error = ?e,
+                        "kaspa rpc: max retries reached"
+                    );
+                    return Err(e);
+                }
+
+                info!(
+                    attempt = attempt,
+                    max_retries = MAX_RETRIES,
+                    error = ?e,
+                    "kaspa rpc: call error, retrying"
+                );
+
+                tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS * attempt as u64)).await;
+                debug!(attempt = attempt + 1, "kaspa rpc: retrying");
+            }
+        }
+    }
+
+    unreachable!("loop should always return or error before reaching here")
+}
+
 /// Executes an RPC call with automatic reconnection on failure.
 ///
 /// If the RPC call fails (e.g., 500 error from disconnected server),
@@ -15,11 +63,13 @@ const RETRY_DELAY_MS: u64 = 1000;
 ///
 /// Usage:
 /// ```ignore
-/// let result = rpc_call_with_retry(&wallet, |w| {
+/// use corelib::rpc_retry::rpc_call_with_reconnect;
+///
+/// let result = rpc_call_with_reconnect(&wallet, |w| {
 ///     Box::pin(async move { w.rpc_api().get_server_info().await })
 /// }).await?;
 /// ```
-pub async fn rpc_call_with_retry<F, Fut, T>(wallet: &Arc<Wallet>, f: F) -> Result<T>
+pub async fn rpc_call_with_reconnect<F, Fut, T>(wallet: &Arc<Wallet>, f: F) -> Result<T>
 where
     F: Fn(Arc<Wallet>) -> Fut,
     Fut: std::future::Future<Output = Result<T>>,

--- a/dymension/libs/kaspa/lib/core/src/rpc_retry.rs
+++ b/dymension/libs/kaspa/lib/core/src/rpc_retry.rs
@@ -1,0 +1,75 @@
+use eyre::Result;
+use kaspa_wallet_core::api::WalletApi;
+use kaspa_wallet_core::wallet::Wallet;
+use std::sync::Arc;
+use std::time::Duration;
+use tracing::{debug, error, info};
+
+const MAX_RETRIES: u32 = 3;
+const RETRY_DELAY_MS: u64 = 1000;
+
+/// Executes an RPC call with automatic reconnection on failure.
+///
+/// If the RPC call fails (e.g., 500 error from disconnected server),
+/// this will disconnect and reconnect the wallet, then retry the call.
+///
+/// Usage:
+/// ```ignore
+/// let result = rpc_call_with_retry(&wallet, |w| {
+///     Box::pin(async move { w.rpc_api().get_server_info().await })
+/// }).await?;
+/// ```
+pub async fn rpc_call_with_retry<F, Fut, T>(wallet: &Arc<Wallet>, f: F) -> Result<T>
+where
+    F: Fn(Arc<Wallet>) -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    for attempt in 1..=MAX_RETRIES {
+        let wallet_clone = wallet.clone();
+        match f(wallet_clone).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                if attempt == MAX_RETRIES {
+                    error!(
+                        attempt = attempt,
+                        max_retries = MAX_RETRIES,
+                        error = ?e,
+                        "kaspa rpc: max retries reached"
+                    );
+                    return Err(e);
+                }
+
+                info!(
+                    attempt = attempt,
+                    max_retries = MAX_RETRIES,
+                    error = ?e,
+                    "kaspa rpc: call error, reconnecting"
+                );
+
+                if let Err(reconnect_err) = reconnect_wallet(wallet).await {
+                    error!(
+                        attempt = attempt,
+                        error = ?reconnect_err,
+                        "kaspa rpc: reconnect error"
+                    );
+                }
+
+                tokio::time::sleep(Duration::from_millis(RETRY_DELAY_MS)).await;
+                debug!(attempt = attempt + 1, "kaspa rpc: retrying");
+            }
+        }
+    }
+
+    unreachable!("loop should always return or error before reaching here")
+}
+
+async fn reconnect_wallet(wallet: &Arc<Wallet>) -> Result<()> {
+    debug!("kaspa rpc: disconnecting");
+    wallet.clone().disconnect().await?;
+
+    debug!("kaspa rpc: connecting");
+    let network_id = wallet.network_id()?;
+    wallet.clone().connect(None, &network_id).await?;
+
+    Ok(())
+}

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -179,12 +179,16 @@ pub async fn validate_new_deposit_inner(
         });
     }
 
-    let containing_block: RpcBlock = client_node
-        .get_block(containing_block_hash, true)
-        .await
-        .map_err(|e| ValidationError::KaspaNodeError {
-            reason: e.to_string(),
-        })?;
+    let containing_block: RpcBlock = corelib::rpc_retry::rpc_call_with_retry(|| async {
+        client_node
+            .get_block(containing_block_hash, true)
+            .await
+            .map_err(|e| eyre::eyre!(e))
+    })
+    .await
+    .map_err(|e| ValidationError::KaspaNodeError {
+        reason: e.to_string(),
+    })?;
 
     let tx_id_rpc =
         d_untrusted


### PR DESCRIPTION
Add simple RPC call wrapper that handles connection failures by reconnecting when errors occur (e.g., 500 from restarted node).

Usage:
  rpc_call_with_retry(&wallet, |w| {
    Box::pin(async move { w.rpc_api().get_server_info().await })
  }).await?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
