### PR TITLE
Fix: typescript CLI add sepolia in registries, verbose error for unknown error type in CLI deployments

### DIFF
--- a/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
+++ b/typescript/infra/config/environments/mainnet3/balances/desiredRelayerBalances.json
@@ -1,4 +1,5 @@
 {
+  "sepolia": 0,
   "abstract": 0.0342,
   "alephzeroevmmainnet": 968,
   "ancient8": 0.0202,

--- a/typescript/infra/config/environments/mainnet3/funding.ts
+++ b/typescript/infra/config/environments/mainnet3/funding.ts
@@ -47,6 +47,7 @@ export const keyFunderConfig: KeyFunderConfig<
   desiredBalancePerChain: desiredRelayerBalancePerChain,
   // if not set, keyfunder defaults to 0
   desiredKathyBalancePerChain: {
+    sepolia: '0',
     ancient8: '0',
     arbitrum: '0.1',
     avalanche: '6',
@@ -103,6 +104,7 @@ export const keyFunderConfig: KeyFunderConfig<
   desiredRebalancerBalancePerChain,
   // if not set, keyfunder defaults to using desired balance * 0.2 as the threshold
   igpClaimThresholdPerChain: {
+    sepolia: '0',
     ancient8: '0.1',
     arbitrum: '0.1',
     avalanche: '2',

--- a/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
+++ b/typescript/sdk/src/providers/SmartProvider/SmartProvider.ts
@@ -461,9 +461,18 @@ export class HyperlaneSmartProvider
       });
     } else {
       this.logger.error(
+        {
+          errors: errors.map((e) => ({
+            message: e?.message,
+            code: e?.code,
+            reason: e?.reason,
+            status: e?.status,
+            stack: e?.stack,
+          })),
+        },
         'Unhandled error case in combined provider error handler',
       );
-      throw Error(fallbackMsg);
+      throw Error(fallbackMsg, { cause: errors[0] });
     }
   }
 }


### PR DESCRIPTION
- The Sepolia change is just some artifact, not really important
- The error change should help us see whats going on in with the EVM contract deployments