### PR TITLE
fix: kaspa relayer lookback overlap interval

### DIFF
--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -115,7 +115,7 @@ impl HttpClient {
         /*
         https://api-tn10.kaspa.org/docs#/Kaspa%20addresses/get_full_transactions_for_address_page_addresses__kaspaAddress__full_transactions_page_get
          */
-        let limit: i64 = 20;
+        let limit: i64 = 500;
         let c = self.get_config();
 
         info!(
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[tokio::test]
-    // #[ignore = "dont hit real api"]
+    #[ignore = "dont hit real api"]
     async fn test_get_deposit_stress() {
         /*
         Tries to check if its really working as we observed that the relayer missed many deposits
@@ -353,9 +353,7 @@ mod tests {
         let address = "kaspatest:pzwcd30pvdn0k4snvj5awkmlm6srzuw8d8e766ff5vwceg2akta3799nq2a3p";
 
         let deposits = client
-            // the first deposit which didnt get seen in the stress test at 12.35 Nov 19 2025 https://explorer-tn10.kaspa.org/txs/c241b6d96df9c5b7f812a10417f685049e305616428123392573f8b5200c8273
-            // .get_deposits_by_address(Some(1763552129987), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
-            // .get_deposits_by_address(Some(1763551862627), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
+            // at time of writing test, am absolutely sure how many deposits are just after this time, because of stress testing
             .get_deposits_by_address(Some(1763568168707), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
             .await;
 

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -106,12 +106,16 @@ impl HttpClient {
         Self { url, client: c }
     }
 
+
     pub async fn get_deposits_by_address(
         &self,
         from_unix_time: Option<i64>,
         address: &str,
         domain_kas: u32,
     ) -> Result<Vec<Deposit>> {
+        /*
+        https://api-tn10.kaspa.org/docs#/Kaspa%20addresses/get_full_transactions_for_address_page_addresses__kaspaAddress__full_transactions_page_get
+         */
         let n: i64 = 500;
 
         let c = self.get_config();
@@ -268,7 +272,7 @@ fn has_valid_hyperlane_payload(tx: &TxModel, domain_kas: u32) -> bool {
 mod tests {
     use super::*;
     use crate::message::ParsedHL;
-    use hardcode::hl::HL_DOMAIN_KASPA_TEST10;
+    use hardcode::hl::{HL_DOMAIN_KASPA_TEST10, HL_DOMAIN_KASPA_TEST10_LEGACY};
 
     #[tokio::test]
     #[ignore = "dont hit real api"]

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -106,6 +106,47 @@ impl HttpClient {
         Self { url, client: c }
     }
 
+    /// Fetches all valid Hyperlane deposits for a given Kaspa address.
+    ///
+    /// This function paginates through all accepted transactions for the address and filters
+    /// for valid Hyperlane deposits (escrow transfers with valid payloads).
+    ///
+    /// # Pagination Strategy
+    ///
+    /// The Kaspa API `/addresses/{kaspaAddress}/full-transactions-page` endpoint supports
+    /// time-based pagination using `before` and `after` query parameters:
+    /// - `before=T`: Returns transactions that occurred EARLIER than timestamp T (where block_time < T)
+    ///   - Example: `before=1000` returns txs at times 999, 998, 997... (older transactions)
+    /// - `after=T`: Returns transactions that occurred LATER than timestamp T (where block_time > T)
+    ///   - Example: `after=1000` returns txs at times 1001, 1002, 1003... (newer transactions)
+    /// - Only one of `before` or `after` can be used per request (mutually exclusive)
+    ///
+    /// This function uses a backward pagination strategy (newest to oldest):
+    /// 1. First request uses `after=lower_bound_unix_time` to get transactions after the checkpoint
+    /// 2. Subsequent requests use `before=oldest_tx_time - 1` to page backward through history
+    /// 3. Continues until reaching `lower_bound_unix_time` or no more transactions exist
+    ///
+    /// # Parameters
+    ///
+    /// - `lower_bound_unix_time`: Optional timestamp (epoch millis) to start scanning from.
+    ///   If None, scans from genesis. Used as checkpoint for incremental syncing.
+    /// - `address`: The Kaspa address to query deposits for
+    /// - `domain_kas`: Expected Kaspa domain ID in the Hyperlane payload for validation
+    ///
+    /// # Returns
+    ///
+    /// Vector of valid Hyperlane deposits, ordered newest to oldest, filtered by:
+    /// - Transaction is accepted (not rejected)
+    /// - Has a payload (required for Hyperlane messages)
+    /// - Is a valid escrow transfer (funds sent to the monitored address)
+    /// - Contains valid Hyperlane payload for the specified domain
+    ///
+    /// # Implementation Notes
+    ///
+    /// - Fetches 500 transactions per page to minimize API calls
+    /// - Filters transactions in-flight to reduce memory usage
+    /// - Updates pagination cursor (`upper_bound_t`) from each transaction's block_time
+    /// - Stops when either: fewer than 500 txs returned OR cursor reaches lower bound
     pub async fn get_deposits_by_address(
         &self,
         lower_bound_unix_time: Option<i64>,

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -106,132 +106,55 @@ impl HttpClient {
         Self { url, client: c }
     }
 
-    /// Fetches all valid Hyperlane deposits for a given Kaspa address.
-    ///
-    /// This function paginates through all accepted transactions for the address and filters
-    /// for valid Hyperlane deposits (escrow transfers with valid payloads).
-    ///
-    /// # Pagination Strategy
-    ///
-    /// The Kaspa API `/addresses/{kaspaAddress}/full-transactions-page` endpoint supports
-    /// time-based pagination using `before` and `after` query parameters:
-    /// - `before=T`: Returns transactions that occurred EARLIER than timestamp T (where block_time < T)
-    ///   - Example: `before=1000` returns txs at times 999, 998, 997... (older transactions)
-    /// - `after=T`: Returns transactions that occurred LATER than timestamp T (where block_time > T)
-    ///   - Example: `after=1000` returns txs at times 1001, 1002, 1003... (newer transactions)
-    /// - Only one of `before` or `after` can be used per request (mutually exclusive)
-    ///
-    /// This function uses a backward pagination strategy (newest to oldest):
-    /// 1. First request: `after=lower_bound_unix_time` gets txs with time > checkpoint
-    ///    - API returns them newest-first, e.g., [12, 11, 10] if limit=3
-    /// 2. Subsequent requests: `before=oldest_seen_time - 1` continues paging backward
-    ///    - Next batch: [9, 8, 7], then [6, 5, 4], etc.
-    /// 3. Stops when: fewer than 500 txs returned OR cursor goes below `lower_bound_unix_time`
-    ///
-    /// Note: API always returns results sorted newest-first regardless of pagination direction
-    ///
-    /// # Parameters
-    ///
-    /// - `lower_bound_unix_time`: Optional timestamp (epoch millis) to start scanning from.
-    ///   If None, scans from genesis. Used as checkpoint for incremental syncing.
-    /// - `address`: The Kaspa address to query deposits for
-    /// - `domain_kas`: Expected Kaspa domain ID in the Hyperlane payload for validation
-    ///
-    /// # Returns
-    ///
-    /// Vector of valid Hyperlane deposits, ordered newest to oldest, filtered by:
-    /// - Transaction is accepted (not rejected)
-    /// - Has a payload (required for Hyperlane messages)
-    /// - Is a valid escrow transfer (funds sent to the monitored address)
-    /// - Contains valid Hyperlane payload for the specified domain
-    ///
-    /// # Implementation Notes
-    ///
-    /// - Fetches 500 transactions per page to minimize API calls
-    /// - Filters transactions in-flight to reduce memory usage
-    /// - Updates pagination cursor (`upper_bound_t`) from each transaction's block_time
-    /// - Stops when either: fewer than 500 txs returned OR cursor reaches lower bound
     pub async fn get_deposits_by_address(
         &self,
-        lower_bound_unix_time: Option<i64>,
+        from_unix_time: Option<i64>,
         address: &str,
         domain_kas: u32,
     ) -> Result<Vec<Deposit>> {
         let n: i64 = 500;
-        let initial_lower_bound_t = lower_bound_unix_time.unwrap_or(0);
-        let mut upper_bound_t = 0i64;
 
         let c = self.get_config();
         info!(url = ?c.base_path, "kaspa: querying deposits");
 
         let mut deposits: Vec<Deposit> = Vec::new();
 
-        let mut lower_bound_t = initial_lower_bound_t;
-        loop {
-            // only upper_bound_t or lower_bound_t can be used in the query, not both.
-            // so in case upper_bound_t is set (>0) it means we need to page and we use the last tx received timestamp as upper_bound_t
-            if upper_bound_t > 0 {
-                lower_bound_t = 0;
+        let res = transactions_page(
+            &c,
+            args {
+                kaspa_address: address.to_string(),
+                limit: Some(n),
+                before: Some(upper_bound_t),
+                after: Some(lower_bound_t),
+                fields: None,
+                resolve_previous_outpoints: Some("no".to_string()),
+                acceptance: Some(AcceptanceMode::Accepted),
+            },
+        )
+        .await?;
+
+        for tx in res {
+            if !is_valid_escrow_transfer(&tx, &address.to_string())? {
+                continue;
             }
 
-            let res = transactions_page(
-                &c,
-                args {
-                    kaspa_address: address.to_string(),
-                    limit: Some(n),
-                    before: Some(upper_bound_t),
-                    after: Some(lower_bound_t),
-                    fields: None,
-                    resolve_previous_outpoints: Some("no".to_string()),
-                    acceptance: Some(AcceptanceMode::Accepted),
-                },
-            )
-            .await?;
-
-            let txs_found = res.len();
-
-            // Update pagination cursor to the oldest transaction's time in this batch.
-            // The API returns transactions sorted newest-first, so the last element is the oldest.
-            if let Some(last_tx) = res.last() {
-                if let Some(t) = last_tx.block_time {
-                    upper_bound_t = t - 1;
-                }
+            if !has_valid_hyperlane_payload(&tx, domain_kas) {
+                continue;
             }
 
-            // Filter and convert in one pass to avoid holding all raw txs in memory
-            for tx in res {
-                // Early exits for cheap checks first
-                if tx.payload.is_none() {
+            let tx_id = tx.transaction_id.clone();
+            let tx_time = tx.block_time;
+            match Deposit::try_from(tx) {
+                Ok(deposit) => deposits.push(deposit),
+                Err(e) => {
+                    tracing::info!(
+                        tx_id = ?tx_id,
+                        block_time = ?tx_time,
+                        error = ?e,
+                        "kaspa: skipped invalid deposit"
+                    );
                     continue;
                 }
-
-                if !is_valid_escrow_transfer(&tx, &address.to_string())? {
-                    continue;
-                }
-
-                if !has_valid_hyperlane_payload(&tx, domain_kas) {
-                    continue;
-                }
-
-                let tx_id = tx.transaction_id.clone();
-                let tx_time = tx.block_time;
-                match Deposit::try_from(tx) {
-                    Ok(deposit) => deposits.push(deposit),
-                    Err(e) => {
-                        tracing::info!(
-                            tx_id = ?tx_id,
-                            block_time = ?tx_time,
-                            error = ?e,
-                            "kaspa: skipped invalid deposit"
-                        );
-                        continue;
-                    }
-                }
-            }
-
-            // if txs found are less than n, or we already did paging till the initial lower bound
-            if txs_found < n as usize || upper_bound_t < initial_lower_bound_t {
-                break;
             }
         }
 
@@ -348,7 +271,7 @@ mod tests {
     use hardcode::hl::HL_DOMAIN_KASPA_TEST10;
 
     #[tokio::test]
-    #[ignore = "dont hil real api"]
+    #[ignore = "dont hit real api"]
     async fn test_get_deposits() {
         // https://explorer-tn10.kaspa.org/addresses/kaspatest:pzlq49spp66vkjjex0w7z8708f6zteqwr6swy33fmy4za866ne90v7e6pyrfr?page=1
         let client = HttpClient::new(
@@ -359,6 +282,37 @@ mod tests {
 
         let deposits = client
             .get_deposits_by_address(Some(1751299515650), address, HL_DOMAIN_KASPA_TEST10)
+            .await;
+
+        match deposits {
+            Ok(deposits) => {
+                println!("Found deposits: n = {:?}", deposits.len());
+                for deposit in deposits {
+                    println!("Deposit: {:?}", deposit);
+                }
+            }
+            Err(e) => {
+                println!("Query deposits: {:?}", e);
+            }
+        }
+    }
+
+    #[tokio::test]
+    #[ignore = "dont hit real api"]
+    async fn test_get_deposit_stress() {
+        /*
+        Tries to check if its really working as we observed that the relayer missed many deposits
+         */
+        let client = HttpClient::new(
+            "https://api-tn10.kaspa.org/".to_string(),
+            RateLimitConfig::default(),
+        );
+        // blumbus address Nov 19 2025
+        let address = "kaspatest:pzwcd30pvdn0k4snvj5awkmlm6srzuw8d8e766ff5vwceg2akta3799nq2a3p";
+
+        let deposits = client
+        // the first deposit which didnt get seen in the stress test at 12.35 Nov 19 2025 https://explorer-tn10.kaspa.org/txs/c241b6d96df9c5b7f812a10417f685049e305616428123392573f8b5200c8273
+            .get_deposits_by_address(Some(1763552129987), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
             .await;
 
         match deposits {

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -116,52 +116,88 @@ impl HttpClient {
         /*
         https://api-tn10.kaspa.org/docs#/Kaspa%20addresses/get_full_transactions_for_address_page_addresses__kaspaAddress__full_transactions_page_get
          */
-        let n: i64 = 500;
-
+        let limit: i64 = 500;
         let c = self.get_config();
-        info!(url = ?c.base_path, "kaspa: querying deposits");
+
+        info!(
+            url = ?c.base_path,
+            address = %address,
+            from_unix_time = ?from_unix_time,
+            "kaspa: querying deposits"
+        );
 
         let mut deposits: Vec<Deposit> = Vec::new();
+        let mut after = from_unix_time;
 
-        let res = transactions_page(
-            &c,
-            args {
-                kaspa_address: address.to_string(),
-                limit: Some(n),
-                before: Some(upper_bound_t),
-                after: Some(lower_bound_t),
-                fields: None,
-                resolve_previous_outpoints: Some("no".to_string()),
-                acceptance: Some(AcceptanceMode::Accepted),
-            },
-        )
-        .await?;
+        loop {
+            let page_txs = transactions_page(
+                &c,
+                args {
+                    kaspa_address: address.to_string(),
+                    limit: Some(limit),
+                    before: None,
+                    after,
+                    fields: None,
+                    resolve_previous_outpoints: Some("no".to_string()),
+                    acceptance: Some(AcceptanceMode::Accepted),
+                },
+            )
+            .await?;
 
-        for tx in res {
-            if !is_valid_escrow_transfer(&tx, &address.to_string())? {
-                continue;
+            let page_count = page_txs.len();
+            info!(
+                page_count = page_count,
+                after = ?after,
+                "kaspa: received transaction page"
+            );
+
+            if page_txs.is_empty() {
+                break;
             }
 
-            if !has_valid_hyperlane_payload(&tx, domain_kas) {
-                continue;
-            }
+            let mut newest_block_time: Option<i64> = None;
 
-            let tx_id = tx.transaction_id.clone();
-            let tx_time = tx.block_time;
-            match Deposit::try_from(tx) {
-                Ok(deposit) => deposits.push(deposit),
-                Err(e) => {
-                    tracing::info!(
-                        tx_id = ?tx_id,
-                        block_time = ?tx_time,
-                        error = ?e,
-                        "kaspa: skipped invalid deposit"
+            for tx in page_txs {
+                if let Some(block_time) = tx.block_time {
+                    newest_block_time = Some(
+                        newest_block_time
+                            .map(|t| t.max(block_time))
+                            .unwrap_or(block_time)
                     );
+                }
+
+                if !is_valid_escrow_transfer(&tx, &address.to_string())? {
                     continue;
                 }
+
+                if !has_valid_hyperlane_payload(&tx, domain_kas) {
+                    continue;
+                }
+
+                let tx_id = tx.transaction_id.clone();
+                let tx_time = tx.block_time;
+                match Deposit::try_from(tx) {
+                    Ok(deposit) => deposits.push(deposit),
+                    Err(e) => {
+                        info!(
+                            tx_id = ?tx_id,
+                            block_time = ?tx_time,
+                            error = ?e,
+                            "kaspa: skipped invalid deposit"
+                        );
+                        continue;
+                    }
+                }
             }
+
+            if (page_count as i64) < limit {
+                break;
+            }
+
+            after = newest_block_time;
         }
 
+        info!(deposits_count = deposits.len(), "kaspa: finished querying deposits");
         Ok(deposits)
     }
 
@@ -302,7 +338,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore = "dont hit real api"]
+    // #[ignore = "dont hit real api"]
     async fn test_get_deposit_stress() {
         /*
         Tries to check if its really working as we observed that the relayer missed many deposits

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -106,7 +106,6 @@ impl HttpClient {
         Self { url, client: c }
     }
 
-
     pub async fn get_deposits_by_address(
         &self,
         from_unix_time: Option<i64>,
@@ -116,7 +115,7 @@ impl HttpClient {
         /*
         https://api-tn10.kaspa.org/docs#/Kaspa%20addresses/get_full_transactions_for_address_page_addresses__kaspaAddress__full_transactions_page_get
          */
-        let limit: i64 = 500;
+        let limit: i64 = 20;
         let c = self.get_config();
 
         info!(
@@ -162,7 +161,7 @@ impl HttpClient {
                     newest_block_time = Some(
                         newest_block_time
                             .map(|t| t.max(block_time))
-                            .unwrap_or(block_time)
+                            .unwrap_or(block_time),
                     );
                 }
 
@@ -197,7 +196,10 @@ impl HttpClient {
             after = newest_block_time;
         }
 
-        info!(deposits_count = deposits.len(), "kaspa: finished querying deposits");
+        info!(
+            deposits_count = deposits.len(),
+            "kaspa: finished querying deposits"
+        );
         Ok(deposits)
     }
 
@@ -351,16 +353,19 @@ mod tests {
         let address = "kaspatest:pzwcd30pvdn0k4snvj5awkmlm6srzuw8d8e766ff5vwceg2akta3799nq2a3p";
 
         let deposits = client
-        // the first deposit which didnt get seen in the stress test at 12.35 Nov 19 2025 https://explorer-tn10.kaspa.org/txs/c241b6d96df9c5b7f812a10417f685049e305616428123392573f8b5200c8273
-            .get_deposits_by_address(Some(1763552129987), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
+            // the first deposit which didnt get seen in the stress test at 12.35 Nov 19 2025 https://explorer-tn10.kaspa.org/txs/c241b6d96df9c5b7f812a10417f685049e305616428123392573f8b5200c8273
+            // .get_deposits_by_address(Some(1763552129987), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
+            // .get_deposits_by_address(Some(1763551862627), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
+            .get_deposits_by_address(Some(1763568168707), address, HL_DOMAIN_KASPA_TEST10_LEGACY)
             .await;
 
         match deposits {
             Ok(deposits) => {
-                println!("Found deposits: n = {:?}", deposits.len());
+                let n = deposits.len();
                 for deposit in deposits {
                     println!("Deposit: {:?}", deposit);
                 }
+                println!("Found deposits: n = {:?}", n);
             }
             Err(e) => {
                 println!("Query deposits: {:?}", e);

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -122,9 +122,13 @@ impl HttpClient {
     /// - Only one of `before` or `after` can be used per request (mutually exclusive)
     ///
     /// This function uses a backward pagination strategy (newest to oldest):
-    /// 1. First request uses `after=lower_bound_unix_time` to get transactions after the checkpoint
-    /// 2. Subsequent requests use `before=oldest_tx_time - 1` to page backward through history
-    /// 3. Continues until reaching `lower_bound_unix_time` or no more transactions exist
+    /// 1. First request: `after=lower_bound_unix_time` gets txs with time > checkpoint
+    ///    - API returns them newest-first, e.g., [12, 11, 10] if limit=3
+    /// 2. Subsequent requests: `before=oldest_seen_time - 1` continues paging backward
+    ///    - Next batch: [9, 8, 7], then [6, 5, 4], etc.
+    /// 3. Stops when: fewer than 500 txs returned OR cursor goes below `lower_bound_unix_time`
+    ///
+    /// Note: API always returns results sorted newest-first regardless of pagination direction
     ///
     /// # Parameters
     ///
@@ -186,13 +190,16 @@ impl HttpClient {
 
             let txs_found = res.len();
 
-            // Filter and convert in one pass to avoid holding all raw txs in memory
-            for tx in res {
-                // Update pagination cursor from last tx regardless of filtering
-                if let Some(t) = tx.block_time {
+            // Update pagination cursor to the oldest transaction's time in this batch.
+            // The API returns transactions sorted newest-first, so the last element is the oldest.
+            if let Some(last_tx) = res.last() {
+                if let Some(t) = last_tx.block_time {
                     upper_bound_t = t - 1;
                 }
+            }
 
+            // Filter and convert in one pass to avoid holding all raw txs in memory
+            for tx in res {
                 // Early exits for cheap checks first
                 if tx.payload.is_none() {
                     continue;

--- a/rust/main/chains/dymension-kaspa/src/conf.rs
+++ b/rust/main/chains/dymension-kaspa/src/conf.rs
@@ -63,6 +63,7 @@ pub struct RelayerDepositTimings {
     pub retry_delay_exponent: f64,
     pub retry_delay_max: std::time::Duration,
     pub deposit_look_back: Option<std::time::Duration>,
+    pub deposit_query_overlap: std::time::Duration,
 }
 
 impl Default for RelayerDepositTimings {
@@ -73,6 +74,7 @@ impl Default for RelayerDepositTimings {
             retry_delay_exponent: 2.0,
             retry_delay_max: std::time::Duration::from_secs(3600),
             deposit_look_back: None,
+            deposit_query_overlap: std::time::Duration::from_secs(60 * 5),
         }
     }
 }

--- a/rust/main/chains/dymension-kaspa/src/conf.rs
+++ b/rust/main/chains/dymension-kaspa/src/conf.rs
@@ -62,7 +62,7 @@ pub struct RelayerDepositTimings {
     pub retry_delay_base: std::time::Duration,
     pub retry_delay_exponent: f64,
     pub retry_delay_max: std::time::Duration,
-    pub deposit_look_back: Option<std::time::Duration>,
+    pub deposit_look_back: std::time::Duration,
     pub deposit_query_overlap: std::time::Duration,
 }
 
@@ -73,16 +73,9 @@ impl Default for RelayerDepositTimings {
             retry_delay_base: std::time::Duration::from_secs(30),
             retry_delay_exponent: 2.0,
             retry_delay_max: std::time::Duration::from_secs(3600),
-            deposit_look_back: None,
+            deposit_look_back: std::time::Duration::from_secs(0),
             deposit_query_overlap: std::time::Duration::from_secs(60 * 5),
         }
-    }
-}
-
-impl RelayerDepositTimings {
-    pub fn lower_bound_unix_time(&self) -> Option<i64> {
-        self.deposit_look_back
-            .map(|dur| kaspa_core::time::unix_now() as i64 - dur.as_millis() as i64)
     }
 }
 

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -115,15 +115,34 @@ where
     async fn deposit_loop(&self) {
         info!("Dymension, starting deposit loop with queue");
 
-        // let from_time = now - timingsConfig.look_back
-        // let last_query_time = zero time / unix epoch / a long time ago 
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("System time before Unix epoch")
+            .as_millis() as i64;
+
+        let mut from_time = Some(now - self.config.deposit_look_back.as_millis() as i64);
+        let mut last_query_time = 0i64;
 
         loop {
             self.process_deposit_queue().await;
 
-            // let to_sleep = max(0, poll_interval - (now - last_query_time))
-            // sleep for to_sleep
-            // set last_query_time = now
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("System time before Unix epoch")
+                .as_millis() as i64;
+
+            let elapsed = now - last_query_time;
+            let poll_interval_ms = self.config.poll_interval.as_millis() as i64;
+            let to_sleep = poll_interval_ms.saturating_sub(elapsed);
+
+            if to_sleep > 0 {
+                time::sleep(Duration::from_millis(to_sleep as u64)).await;
+            }
+
+            last_query_time = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("System time before Unix epoch")
+                .as_millis() as i64;
 
             match self
                 .provider
@@ -142,7 +161,9 @@ where
                     error!(error = ?e, "Dymension, query new Kaspa deposits failed");
                 }
             }
-            // set from_time = last_query_time - timingsConfig.query_overlap
+
+            from_time =
+                Some(last_query_time - self.config.deposit_query_overlap.as_millis() as i64);
         }
     }
 

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -115,36 +115,21 @@ where
     async fn deposit_loop(&self) {
         info!("Dymension, starting deposit loop with queue");
 
-        let overlap_ms = self.config.deposit_query_overlap.as_millis() as i64;
-        let mut last_query_time: Option<i64> = None;
+        // let from_time = now - timingsConfig.look_back
+        // let last_query_time = zero time / unix epoch / a long time ago 
 
         loop {
-            let loop_start = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("System time before Unix epoch")
-                .as_millis() as i64;
-
             self.process_deposit_queue().await;
 
-            let query_start = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("System time before Unix epoch")
-                .as_millis() as i64;
-
-            let lower_bound = match last_query_time {
-                None => self
-                    .config
-                    .deposit_look_back
-                    .map(|d| query_start - d.as_millis() as i64),
-                Some(last) => Some(last - overlap_ms),
-            };
+            // let to_sleep = max(0, poll_interval - (now - last_query_time))
+            // sleep for to_sleep
 
             match self
                 .provider
                 .rest()
                 .get_deposits(
                     &self.provider.escrow_address().to_string(),
-                    lower_bound,
+                    from_time,
                     self.provider.domain().id(),
                 )
                 .await
@@ -156,21 +141,8 @@ where
                     error!(error = ?e, "Dymension, query new Kaspa deposits failed");
                 }
             }
-
-            let loop_end = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .expect("System time before Unix epoch")
-                .as_millis() as i64;
-
-            last_query_time = Some(query_start);
-
-            let elapsed = loop_end - loop_start;
-            let poll_interval_ms = self.config.poll_interval.as_millis() as i64;
-            let sleep_ms = poll_interval_ms.saturating_sub(elapsed);
-
-            if sleep_ms > 0 {
-                time::sleep(Duration::from_millis(sleep_ms as u64)).await;
-            }
+            // set last_query_time = now
+            // set from_time = last_query_time - timingsConfig.query_overlap
         }
     }
 

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -121,7 +121,7 @@ where
         loop {
             self.process_deposit_queue().await;
 
-            let now = std::time::SystemTime::now()
+            let query_start = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("System time before Unix epoch")
                 .as_millis() as i64;
@@ -130,7 +130,7 @@ where
                 None => self
                     .config
                     .deposit_look_back
-                    .map(|d| now - d.as_millis() as i64),
+                    .map(|d| query_start - d.as_millis() as i64),
                 Some(last) => Some(last - overlap_ms),
             };
 
@@ -152,8 +152,20 @@ where
                 }
             }
 
-            last_query_time = Some(now);
-            time::sleep(self.config.poll_interval).await;
+            let query_end = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("System time before Unix epoch")
+                .as_millis() as i64;
+
+            last_query_time = Some(query_start);
+
+            let elapsed = query_end - query_start;
+            let poll_interval_ms = self.config.poll_interval.as_millis() as i64;
+            let sleep_ms = poll_interval_ms.saturating_sub(elapsed);
+
+            if sleep_ms > 0 {
+                time::sleep(Duration::from_millis(sleep_ms as u64)).await;
+            }
         }
     }
 

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -123,6 +123,7 @@ where
 
             // let to_sleep = max(0, poll_interval - (now - last_query_time))
             // sleep for to_sleep
+            // set last_query_time = now
 
             match self
                 .provider
@@ -141,7 +142,6 @@ where
                     error!(error = ?e, "Dymension, query new Kaspa deposits failed");
                 }
             }
-            // set last_query_time = now
             // set from_time = last_query_time - timingsConfig.query_overlap
         }
     }

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -119,6 +119,11 @@ where
         let mut last_query_time: Option<i64> = None;
 
         loop {
+            let loop_start = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .expect("System time before Unix epoch")
+                .as_millis() as i64;
+
             self.process_deposit_queue().await;
 
             let query_start = std::time::SystemTime::now()
@@ -152,14 +157,14 @@ where
                 }
             }
 
-            let query_end = std::time::SystemTime::now()
+            let loop_end = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .expect("System time before Unix epoch")
                 .as_millis() as i64;
 
             last_query_time = Some(query_start);
 
-            let elapsed = query_end - query_start;
+            let elapsed = loop_end - loop_start;
             let poll_interval_ms = self.config.poll_interval.as_millis() as i64;
             let sleep_ms = poll_interval_ms.saturating_sub(elapsed);
 

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -115,9 +115,8 @@ where
     async fn deposit_loop(&self) {
         info!("Dymension, starting deposit loop with queue");
 
-        // First iteration: use full lookback to catch up on missed deposits
-        // Subsequent iterations: only look back 2x poll interval to handle clock skew
-        let mut lookback_ms = self.config.deposit_look_back.map(|d| d.as_millis() as i64);
+        let overlap_ms = self.config.deposit_query_overlap.as_millis() as i64;
+        let mut last_query_time: Option<i64> = None;
 
         loop {
             self.process_deposit_queue().await;
@@ -127,7 +126,13 @@ where
                 .expect("System time before Unix epoch")
                 .as_millis() as i64;
 
-            let lower_bound = lookback_ms.map(|lb| now - lb);
+            let lower_bound = match last_query_time {
+                None => self
+                    .config
+                    .deposit_look_back
+                    .map(|d| now - d.as_millis() as i64),
+                Some(last) => Some(last - overlap_ms),
+            };
 
             match self
                 .provider
@@ -147,7 +152,7 @@ where
                 }
             }
 
-            lookback_ms = Some(self.config.poll_interval.as_millis() as i64 * 4); // look back 4x poll interval to account for any slowness
+            last_query_time = Some(now);
             time::sleep(self.config.poll_interval).await;
         }
     }

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -509,7 +509,8 @@ pub fn build_kaspa_connection_conf(
                 .chain(err)
                 .get_opt_key("depositLookBack")
                 .parse_duration()
-                .end(),
+                .end()
+                .unwrap_or(std::time::Duration::from_secs(0)),
             deposit_query_overlap: chain
                 .chain(err)
                 .get_opt_key("depositQueryOverlap")

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -504,7 +504,7 @@ pub fn build_kaspa_connection_conf(
                 .get_opt_key("depositRetryDelayMax")
                 .parse_duration()
                 .end()
-                .unwrap_or(std::time::Duration::from_secs(3600)),
+                .unwrap_or(std::time::Duration::from_secs(60*60)),
             deposit_look_back: chain
                 .chain(err)
                 .get_opt_key("depositLookBack")

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -510,6 +510,12 @@ pub fn build_kaspa_connection_conf(
                 .get_opt_key("depositLookBack")
                 .parse_duration()
                 .end(),
+            deposit_query_overlap: chain
+                .chain(err)
+                .get_opt_key("depositQueryOverlap")
+                .parse_duration()
+                .end()
+                .unwrap_or(std::time::Duration::from_secs(60 * 5)),
         })
     } else {
         None

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -504,7 +504,7 @@ pub fn build_kaspa_connection_conf(
                 .get_opt_key("depositRetryDelayMax")
                 .parse_duration()
                 .end()
-                .unwrap_or(std::time::Duration::from_secs(60*60)),
+                .unwrap_or(std::time::Duration::from_secs(60 * 60)),
             deposit_look_back: chain
                 .chain(err)
                 .get_opt_key("depositLookBack")


### PR DESCRIPTION
- fix query bug which would fail if more than 500 deposits available
- add a more correct lookback overlap