### PR TITLE
fix: allow env arg in escrow addr derivation

### DIFF
--- a/dymension/libs/kaspa/tooling/src/main.rs
+++ b/dymension/libs/kaspa/tooling/src/main.rs
@@ -27,7 +27,7 @@ async fn run(cli: Cli) {
                 .split(",")
                 .map(|s| s.trim())
                 .collect::<Vec<_>>();
-            let e = x::escrow::get_escrow_address(pub_keys, args.required_signatures);
+            let e = x::escrow::get_escrow_address(pub_keys, args.required_signatures, &args.env);
             println!("Escrow address: {e}");
         }
         Commands::Validator { action } => match action {

--- a/dymension/libs/kaspa/tooling/src/x/args.rs
+++ b/dymension/libs/kaspa/tooling/src/x/args.rs
@@ -87,6 +87,9 @@ pub struct EscrowCli {
     /// Required signatures
     #[arg(required = true, index = 2)]
     pub required_signatures: u8,
+    /// Kaspa environment (testnet or mainnet)
+    #[arg(long, required = true)]
+    pub env: String,
 }
 
 #[derive(Args, Debug)]

--- a/dymension/libs/kaspa/tooling/src/x/escrow.rs
+++ b/dymension/libs/kaspa/tooling/src/x/escrow.rs
@@ -3,11 +3,16 @@ use kaspa_addresses::Prefix;
 use secp256k1::PublicKey;
 use std::str::FromStr;
 
-pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8) -> String {
+pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8, env: &str) -> String {
+    let prefix = match env {
+        "mainnet" => Prefix::Mainnet,
+        "testnet" => Prefix::Testnet,
+        _ => panic!("invalid env: {env}, must be 'testnet' or 'mainnet'"),
+    };
     let pub_keys = pub_keys
         .iter()
         .map(|s| PublicKey::from_str(s).unwrap())
         .collect::<Vec<_>>();
-    let e = EscrowPublic::from_pubs(pub_keys, Prefix::Testnet, required_signatures);
+    let e = EscrowPublic::from_pubs(pub_keys, prefix, required_signatures);
     e.addr.to_string()
 }


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
