### PR TITLE
fix(kaspa): implement mainnet network support in NetworkInfo::new

### DIFF
--- a/dymension/libs/kaspa/lib/core/src/wallet.rs
+++ b/dymension/libs/kaspa/lib/core/src/wallet.rs
@@ -209,9 +209,14 @@ impl NetworkInfo {
                 address_version: Version::PubKey,
                 rpc_url,
             },
-            _ => todo!("only tn10 supported"),
+            Network::KaspaMainnet => Self {
+                network_id: NetworkId::new(NetworkType::Mainnet),
+                network_type: NetworkType::Mainnet,
+                address_prefix: Prefix::Mainnet,
+                address_version: Version::PubKey,
+                rpc_url,
+            },
         }
-        // TODO: finish
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix critical bug where `NetworkInfo::new()` would panic with `todo!("only tn10 supported")` when called with `Network::KaspaMainnet`
- This would cause validators and relayers to crash when configured for Kaspa mainnet
- Add proper mainnet configuration with correct `NetworkId`, `NetworkType::Mainnet`, and `Prefix::Mainnet`

## Affected call chain

```
rust/main/chains/dymension-kaspa/src/providers/provider.rs:78
  └─ KasProvider::new() calls get_easy_wallet()
      └─ rust/main/chains/dymension-kaspa/src/providers/provider.rs:553
          └─ get_easy_wallet() calls EasyKaspaWallet::try_new()
              └─ dymension/libs/kaspa/lib/core/src/wallet.rs:109
                  └─ EasyKaspaWallet::try_new() calls NetworkInfo::new() ← FIXED
```

`KasProvider` is instantiated by both the **validator** and **relayer** agents when configured for Kaspa domains. When `domain_to_kas_network()` returns `Network::KaspaMainnet`, the call to `NetworkInfo::new()` would panic.

## Related issues

Similar to #341 which fixed hardcoded network in escrow address derivation.

## Test plan

- [x] Code compiles with `cargo check`
- [ ] Test with mainnet configuration to verify no panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)