### PR TITLE
fix: kaspa bridge dymension domain id mainnet hardcoded value

### DIFF
--- a/dymension/libs/kaspa/lib/hardcode/src/hl.rs
+++ b/dymension/libs/kaspa/lib/hardcode/src/hl.rs
@@ -1,6 +1,6 @@
 pub const ALLOWED_HL_MESSAGE_VERSION: u8 = 3;
 
-pub const HL_DOMAIN_DYM_MAINNET: u32 = 180352072;
+pub const HL_DOMAIN_DYM_MAINNET: u32 = 1570310961; // NOTE: was patched to this value just before mainnet release. The old value did not do modulo on derivation.
 pub const HL_DOMAIN_DYM_LOCAL: u32 = 587907060;
 pub const HL_DOMAIN_DYM_TESTNET_BLUMBUS: u32 = 482195613;
 pub const HL_DOMAIN_DYM_PLAYGROUND_202507: u32 = 180353102;


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
