### PR TITLE
fix: kaspa validator docs clearer sub object replacement for non-baremetal

### DIFF
--- a/dymension/validators/bridge/README_bridge_kaspa.md
+++ b/dymension/validators/bridge/README_bridge_kaspa.md
@@ -310,7 +310,7 @@ cp -r ${HOME}/hyperlane-monorepo/dymension/validators/bridge/artifacts/<network>
 
 **Configure agent to use AWS KMS:**
 
-1. Add a pointer to your AWS hosted key which allows minting of KAS on Dymension (replacing the preexisting 'validator' subobject):
+1. Add a pointer to your AWS hosted key which allows minting of KAS on Dymension (⚠️ *replacing* the preexisting 'validator' subobject ⚠️):
 
 ```json
 // in the TOP LEVEL object
@@ -321,7 +321,7 @@ cp -r ${HOME}/hyperlane-monorepo/dymension/validators/bridge/artifacts/<network>
     }
 ```
 
-2. Add a pointer to your AWS hosted key which allows release KAS escrow:
+2. Add a pointer to your AWS hosted key which allows release KAS escrow (⚠️ this is a new field ⚠️):
 
 ```json
 // in the chains.<kaspa-network-name> object


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
