### PR TITLE
feat: kaspa add mainnet stress tool support

### DIFF
--- a/dymension/libs/kaspa/tooling/src/x/args.rs
+++ b/dymension/libs/kaspa/tooling/src/x/args.rs
@@ -192,6 +192,10 @@ pub struct SimulateTrafficCli {
     /// Withdrawal fee percentage as decimal in [0,1] (e.g. 0.01 for 1%)
     #[arg(long, required = true)]
     pub withdrawal_fee_pct: f64,
+
+    /// Kaspa network (testnet or mainnet)
+    #[arg(long, required = true)]
+    pub kaspa_network: String,
 }
 
 #[derive(Args, Debug, Clone)]


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
