### PR TITLE
fix: kaspa bridge stress tool properly support mainnet chain ID

### DIFF
--- a/dymension/libs/kaspa/tooling/src/sim/key_cosmos.rs
+++ b/dymension/libs/kaspa/tooling/src/sim/key_cosmos.rs
@@ -5,7 +5,7 @@ use rand_core::OsRng;
 
 #[derive(Clone)]
 pub struct EasyHubKey {
-    private: K256SigningKey,
+    pub private: K256SigningKey,
 }
 
 impl EasyHubKey {

--- a/dymension/libs/kaspa/tooling/src/sim/key_kaspa.rs
+++ b/dymension/libs/kaspa/tooling/src/sim/key_kaspa.rs
@@ -1,8 +1,9 @@
 use kaspa_addresses::{Address, Prefix, Version};
-use secp256k1::{Keypair, Secp256k1};
+use secp256k1::{Keypair, Secp256k1, SecretKey};
 
 pub struct EasyKaspaKey {
     pub address: Address,
+    pub private_key: SecretKey,
 }
 
 pub fn get_kaspa_keypair(prefix: Prefix) -> EasyKaspaKey {
@@ -11,7 +12,10 @@ pub fn get_kaspa_keypair(prefix: Prefix) -> EasyKaspaKey {
     let keypair = Keypair::new(&secp, &mut rng);
     let pub_key = keypair.public_key().x_only_public_key().0;
     let address = Address::new(prefix, Version::PubKey, &pub_key.serialize());
-    EasyKaspaKey { address }
+    EasyKaspaKey {
+        address,
+        private_key: keypair.secret_key(),
+    }
 }
 
 #[cfg(test)]

--- a/dymension/libs/kaspa/tooling/src/sim/key_kaspa.rs
+++ b/dymension/libs/kaspa/tooling/src/sim/key_kaspa.rs
@@ -5,12 +5,12 @@ pub struct EasyKaspaKey {
     pub address: Address,
 }
 
-pub fn get_kaspa_keypair() -> EasyKaspaKey {
+pub fn get_kaspa_keypair(prefix: Prefix) -> EasyKaspaKey {
     let secp = Secp256k1::new();
     let mut rng = rand_08::thread_rng();
     let keypair = Keypair::new(&secp, &mut rng);
     let pub_key = keypair.public_key().x_only_public_key().0;
-    let address = Address::new(Prefix::Testnet, Version::PubKey, &pub_key.serialize());
+    let address = Address::new(prefix, Version::PubKey, &pub_key.serialize());
     EasyKaspaKey { address }
 }
 
@@ -20,7 +20,7 @@ mod tests {
 
     #[test]
     fn test_get_kaspa_keypair_print_address() {
-        let key = get_kaspa_keypair();
+        let key = get_kaspa_keypair(Prefix::Testnet);
         println!("{}", key.address);
     }
 }

--- a/dymension/libs/kaspa/tooling/src/sim/round_trip.rs
+++ b/dymension/libs/kaspa/tooling/src/sim/round_trip.rs
@@ -420,6 +420,10 @@ impl<'a> RoundTrip<'a> {
         };
         let kaspa_recipient = get_kaspa_keypair(kaspa_prefix);
         let hub_user_addr = hub_user_key.signer().address_string.clone();
+        info!(
+            "kaspa_recipient_key: {:?}",
+            kaspa_recipient.private_key.secret_bytes()
+        );
         debug!(
             "withdraw starting: task_id={} hub_whale_id={} hub_user_addr={} kaspa_recipient_addr={} amount={} fee_amount={} fee_denom={}",
             self.task_id, self.hub_whale.id, hub_user_addr, kaspa_recipient.address, withdrawal_amount, fee_amount, fee_denom

--- a/dymension/libs/kaspa/tooling/src/sim/round_trip.rs
+++ b/dymension/libs/kaspa/tooling/src/sim/round_trip.rs
@@ -7,6 +7,7 @@ use crate::x;
 use cometbft_rpc::endpoint::broadcast::tx_commit::Response as HubResponse;
 use corelib::api::client::HttpClient;
 use corelib::user::payload::make_deposit_payload_easy;
+use corelib::wallet::Network;
 use cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend;
 use cosmos_sdk_proto::cosmos::base::v1beta1::Coin;
 use cosmrs::Any;
@@ -116,6 +117,7 @@ pub struct TaskResources {
     pub hub: CosmosProvider<ModuleQueryClient>,
     pub args: TaskArgs,
     pub kas_rest: HttpClient,
+    pub kaspa_network: Network,
 }
 
 #[derive(Debug, Clone)]
@@ -172,6 +174,7 @@ pub async fn do_round_trip(
 
 async fn do_round_trip_inner(rt: &mut RoundTrip<'_>) {
     let hub_user_key = EasyHubKey::new();
+    info!("hub_user_key: {:?}", hub_user_key.private.to_bytes());
     let hub_user_addr = hub_user_key.signer().address_string.clone();
 
     rt.stats.deposit_addr_hub = Some(hub_user_addr.clone());
@@ -411,7 +414,11 @@ impl<'a> RoundTrip<'a> {
         let fee_amount = self.res.args.deposit_amount - withdrawal_amount;
         let fee_denom = self.res.args.hub_denom();
 
-        let kaspa_recipient = get_kaspa_keypair();
+        let kaspa_prefix = match self.res.kaspa_network {
+            Network::KaspaTest10 => kaspa_addresses::Prefix::Testnet,
+            Network::KaspaMainnet => kaspa_addresses::Prefix::Mainnet,
+        };
+        let kaspa_recipient = get_kaspa_keypair(kaspa_prefix);
         let hub_user_addr = hub_user_key.signer().address_string.clone();
         debug!(
             "withdraw starting: task_id={} hub_whale_id={} hub_user_addr={} kaspa_recipient_addr={} amount={} fee_amount={} fee_denom={}",

--- a/dymension/libs/kaspa/tooling/src/sim/sim.rs
+++ b/dymension/libs/kaspa/tooling/src/sim/sim.rs
@@ -141,6 +141,7 @@ impl TrafficSim {
             args: args.task_args,
             hub: first_hub_whale.provider.clone(),
             kas_rest: HttpClient::new(args.kaspa_rest_url.clone(), RateLimitConfig::default()),
+            kaspa_network: args.kaspa_network.clone(),
         };
 
         Ok(TrafficSim {


### PR DESCRIPTION
### Description

<!--
What's included in this PR?
-->

### Drive-by changes

<!--
Are there any minor or drive-by changes also included?
-->

### Related issues

<!--
- Fixes #[issue number here]
-->

### Backward compatibility

<!--
Are these changes backward compatible? Are there any infrastructure implications, e.g. changes that would prohibit deploying older commits using this infra tooling?

Yes/No
-->

### Testing

<!--
What kind of testing have these changes undergone?

None/Manual/Unit Tests
-->
