### PR TITLE
claude: more noisy relayer logs in checkpoint creation

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -210,7 +210,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
     ) -> Result<MultisigCheckpointSyncer, CheckpointSyncerBuildError> {
         let storage_locations = self.fetch_storage_locations(validators).await?;
 
-        debug!(
+        info!(
             hyp_message=?message,
             ?validators,
             validators_len = ?validators.len(),
@@ -225,7 +225,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
             .iter()
             .zip(storage_locations)
             .filter_map(|(validator, validator_storage_locations)| {
-                debug!(hyp_message=?message, ?validator, ?validator_storage_locations, "Validator and its storage locations for message");
+                info!(hyp_message=?message, ?validator, ?validator_storage_locations, "Validator and its storage locations for message");
                 if validator_storage_locations.is_empty() {
                     // If the validator has not announced any storage locations, we skip it
                     // and log a warning.
@@ -237,7 +237,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
                     // Reverse the order of storage locations to prefer the most recently announced
                     for storage_location in validator_storage_locations.iter().rev() {
                         let Ok(config) = CheckpointSyncerConf::from_str(storage_location) else {
-                            debug!(
+                            info!(
                                 ?validator,
                                 ?storage_location,
                                 "Could not parse checkpoint syncer config for validator"
@@ -250,7 +250,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
                         if !self.allow_local_checkpoint_syncers
                             && matches!(config, CheckpointSyncerConf::LocalStorage { .. })
                         {
-                            debug!(
+                            info!(
                                 ?config,
                                 "Ignoring disallowed LocalStorage based checkpoint syncer"
                             );
@@ -286,6 +286,14 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
         for (validator, checkpoint_syncer) in checkpoint_syncers_results {
             checkpoint_syncers.insert(validator.into(), checkpoint_syncer.into());
         }
+
+        info!(
+            hyp_message=?message,
+            checkpoint_syncers_count = checkpoint_syncers.len(),
+            validators_count = validators.len(),
+            ?checkpoint_syncers,
+            "Successfully built checkpoint syncers"
+        );
 
         Ok(MultisigCheckpointSyncer::new(
             checkpoint_syncers,
@@ -333,7 +341,7 @@ impl BaseMetadataBuilder {
                 return Err(CheckpointSyncerBuildError::ReorgEvent(reorg_event));
             }
             Err(err) => {
-                debug!(
+                info!(
                     error=%err,
                     ?config,
                     ?validator,

--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -8,7 +8,7 @@ use futures::{stream, StreamExt};
 use hyperlane_ethereum::Signers;
 use maplit::hashmap;
 use tokio::sync::RwLock;
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, OptionalCache},

--- a/rust/main/hyperlane-base/src/types/multisig.rs
+++ b/rust/main/hyperlane-base/src/types/multisig.rs
@@ -65,11 +65,11 @@ impl MultisigCheckpointSyncer {
         for (validator, latest_index) in validator_index_results {
             match latest_index {
                 Ok(Some(index)) => {
-                    debug!(?validator, ?index, "Validator returned latest index");
+                    info!(?validator, ?index, "Validator returned latest index");
                     latest_indices.insert(*validator, Some(index));
                 }
                 Ok(None) => {
-                    debug!(?validator, "Validator returned no latest index");
+                    info!(?validator, "Validator returned no latest index");
                     latest_indices.insert(*validator, None);
                 }
                 Err(err) => {
@@ -157,6 +157,16 @@ impl MultisigCheckpointSyncer {
                 );
                 return Ok(None);
             }
+
+            info!(
+                %minimum_index,
+                %start_index,
+                %highest_quorum_index,
+                validators_with_indices = latest_indices.len(),
+                threshold,
+                ?latest_indices,
+                "Searching for checkpoint in range"
+            );
 
             for index in (minimum_index..=start_index).rev() {
                 let checkpoint_res = self.fetch_checkpoint(validators, threshold, index).await;


### PR DESCRIPTION
## Summary

Upgrades critical diagnostic logs from `debug!` to `info!` level in the metadata fetching flow to make them visible when the relayer runs at info log level. This improves troubleshooting for checkpoint quorum failures.

## Changes

**[rust/main/hyperlane-base/src/types/multisig.rs](rust/main/hyperlane-base/src/types/multisig.rs)**
- Changed validator index fetch result logging from `debug!` to `info!` (lines 65-80)
- Added `info!` log showing checkpoint search range details before iteration (line 161-169)

**[rust/main/agents/relayer/src/msg/metadata/base_builder.rs](rust/main/agents/relayer/src/msg/metadata/base_builder.rs)**
- Changed validator storage locations list log from `debug!` to `info!` (line 213)
- Changed per-validator storage location log from `debug!` to `info!` (line 228)
- Changed checkpoint syncer config parse failure log from `debug!` to `info!` (line 240)
- Changed LocalStorage rejection log from `debug!` to `info!` (line 253)
- Changed checkpoint syncer loading error log from `debug!` to `info!` (line 336)
- Added summary log showing successful checkpoint syncer count (line 290-296)

## Context

When debugging Sepolia -> Dymension transfers failing with "CouldNotFetchMetadata" errors, we need better visibility into:
- Whether validators are returning latest indices
- What storage locations are being discovered
- Whether checkpoint syncers are being built successfully
- What checkpoint ranges are being searched

Previously these diagnostics were only visible at `debug` level, but the production relayer runs at `info` level.

## Test Plan

- [x] Code compiles and passes `cargo fmt --check`
- [x] Pre-commit hooks pass (gitleaks, cargo fmt)
- [ ] Deploy to relayer and verify new logs appear at info level
- [ ] Use new logs to diagnose actual root cause of metadata fetch failures

Generated with [Claude Code](https://claude.com/claude-code)