### PR TITLE
Improve merkle root multisig metadata build logging

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/merkle_root_multisig.rs
@@ -7,7 +7,7 @@ use derive_new::new;
 use eyre::Result;
 use hyperlane_base::MultisigCheckpointSyncer;
 use hyperlane_core::{unwrap_or_none_result, HyperlaneMessage, ModuleType, H256};
-use tracing::debug;
+use tracing::info;
 
 use crate::msg::metadata::{MessageMetadataBuilder, MetadataBuildError};
 
@@ -42,14 +42,14 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
     ) -> Result<Option<MultisigMetadata>, MetadataBuildError> {
         let highest_leaf_index = unwrap_or_none_result!(
             self.base_builder().highest_known_leaf_index().await,
-            debug!("Couldn't get highest known leaf index")
+            info!("Couldn't get highest known leaf index")
         );
         let leaf_index = unwrap_or_none_result!(
             self.base_builder()
                 .get_merkle_leaf_id_by_message_id(message.id())
                 .await
                 .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?,
-            debug!(
+            info!(
                 hyp_message=?message,
                 "No merkle leaf found for message id, must have not been enqueued in the tree"
             )
@@ -66,7 +66,7 @@ impl MultisigIsmMetadataBuilder for MerkleRootMultisigMetadataBuilder {
                 )
                 .await
                 .map_err(|err| MetadataBuildError::FailedToBuild(err.to_string()))?,
-            debug!(
+            info!(
                 leaf_index,
                 highest_leaf_index, "Couldn't get checkpoint in range"
             )


### PR DESCRIPTION
## Summary

Upgrade debug! logs to info! level in `merkle_root_multisig.rs` to make early return diagnostics visible when troubleshooting metadata build failures.

This PR makes visible three critical failure points that can cause "CouldNotFetchMetadata" errors:
- `highest_known_leaf_index` fetch failures
- Merkle leaf lookup failures  
- `checkpoint_in_range` fetch failures

## Context

Building on PR #353, this change upgrades the remaining debug! logs in the metadata build flow. Previously, when the metadata builder hit early returns via `unwrap_or_none_result!` macros, these failures were only logged at debug level and invisible when running with `--log.level info`.

## Changes

- Changed `use tracing::debug` to `use tracing::info`
- Upgraded three debug! log statements to info! level in `fetch_metadata()` method

## Related

- PR #353: Initial improvements to metadata build logging
- Issue: Debugging Sepolia → Dymension transfer failures

Generated with [Claude Code](https://claude.com/claude-code)