### PR TITLE
Agent version endpoint and fix Kaspa dust threshold retry loop

### DIFF
--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs
@@ -288,21 +288,34 @@ fn create_withdrawal_pskt(
 
 /// Return outputs generated based on the provided messages. Filter out messages
 /// with dust amount.
+///
+/// Returns:
+/// - Vec of valid messages (will be processed)
+/// - Vec of transaction outputs (for valid messages)
+/// - Vec of skipped messages (dust or parse errors, should not be retried)
 pub fn get_outputs_from_msgs(
     messages: Vec<HyperlaneMessage>,
     prefix: Prefix,
     min_withdrawal_sompi: U256,
-) -> (Vec<HyperlaneMessage>, Vec<TransactionOutput>) {
+) -> (
+    Vec<HyperlaneMessage>,
+    Vec<TransactionOutput>,
+    Vec<HyperlaneMessage>,
+) {
     let mut hl_msgs: Vec<HyperlaneMessage> = Vec::new();
     let mut outputs: Vec<TransactionOutput> = Vec::new();
+    let mut skipped_msgs: Vec<HyperlaneMessage> = Vec::new();
+
     for m in messages {
         let tm = match parse_hyperlane_metadata(&m) {
             Ok(tm) => tm,
             Err(e) => {
                 info!(
                     error = %e,
-                    "kaspa relayer: skipped message, failed to parse TokenMessage from HyperlaneMessage body"
+                    message_id = ?m.id(),
+                    "kaspa relayer: permanently skipped message, failed to parse TokenMessage from HyperlaneMessage body"
                 );
+                skipped_msgs.push(m);
                 continue;
             }
         };
@@ -315,15 +328,16 @@ pub fn get_outputs_from_msgs(
             info!(
                 amount = o.value,
                 message_id = ?m.id(),
-                "kaspa relayer: skipped withdrawal, amount below minimum withdrawal threshold"
+                "kaspa relayer: permanently skipped withdrawal, amount below minimum withdrawal threshold"
             );
+            skipped_msgs.push(m);
             continue;
         }
 
         outputs.push(o);
         hl_msgs.push(m);
     }
-    (hl_msgs, outputs)
+    (hl_msgs, outputs, skipped_msgs)
 }
 
 async fn get_utxo_to_spend(

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
@@ -101,8 +101,8 @@ fn adjust_outputs_for_mass_limit(
     }
 }
 
-/// Processes given messages and returns WithdrawFXG and the very first outpoint
-/// (the one preceding all the given transfers; it should be used during process indication).
+/// Processes given messages and returns WithdrawFXG and skipped messages.
+/// Skipped messages are those filtered out due to dust threshold or parse errors.
 pub async fn on_new_withdrawals(
     messages: Vec<HyperlaneMessage>,
     relayer: EasyKaspaWallet,
@@ -112,7 +112,7 @@ pub async fn on_new_withdrawals(
     tx_fee_multiplier: f64,
     max_sweep_inputs: Option<usize>,
     max_sweep_bundle_bytes: usize,
-) -> Result<Option<WithdrawFXG>> {
+) -> Result<(Option<WithdrawFXG>, Vec<HyperlaneMessage>)> {
     let (current_anchor, pending_msgs) = filter_pending_withdrawals(messages, cosmos.query())
         .await
         .map_err(|e| eyre::eyre!("Get pending withdrawals: {}", e))?;
@@ -141,9 +141,9 @@ pub async fn build_withdrawal_fxg(
     tx_fee_multiplier: f64,
     max_sweep_inputs: Option<usize>,
     max_sweep_bundle_bytes: usize,
-) -> Result<Option<WithdrawFXG>> {
+) -> Result<(Option<WithdrawFXG>, Vec<HyperlaneMessage>)> {
     // Filter out dust messages and create Kaspa outputs for the rest
-    let (valid_msgs, outputs) = get_outputs_from_msgs(
+    let (valid_msgs, outputs, skipped_msgs) = get_outputs_from_msgs(
         pending_msgs,
         relayer.net.address_prefix,
         min_withdrawal_sompi,
@@ -151,7 +151,7 @@ pub async fn build_withdrawal_fxg(
 
     if outputs.is_empty() {
         info!("kaspa relayer: no valid pending withdrawals found, all in batch already processed and confirmed on hub");
-        return Ok(None); // nothing to process
+        return Ok((None, skipped_msgs)); // nothing to process
     }
 
     // Get all the UTXOs for the escrow and the relayer
@@ -185,7 +185,7 @@ pub async fn build_withdrawal_fxg(
             "Relayer has no UTXOs available. Cannot process withdrawals without relayer funds to pay transaction fees. \
             Please fund relayer address. All withdrawal operations will be marked as failed and retried later."
         );
-        return Ok(None);
+        return Ok((None, skipped_msgs));
     }
 
     let (sweeping_bundle, inputs, adjusted_outputs, adjusted_msgs) = if escrow_inputs.len()
@@ -313,11 +313,14 @@ pub async fn build_withdrawal_fxg(
         None => Bundle::from(pskt),
     };
 
-    Ok(Some(WithdrawFXG::new(
-        bundle,
-        messages,
-        vec![current_anchor, new_anchor],
-    )))
+    Ok((
+        Some(WithdrawFXG::new(
+            bundle,
+            messages,
+            vec![current_anchor, new_anchor],
+        )),
+        skipped_msgs,
+    ))
 }
 
 #[cfg(test)]

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -100,6 +100,7 @@ pub struct Relayer {
     agent_metrics: AgentMetrics,
     chain_metrics: ChainMetrics,
     runtime_metrics: RuntimeMetrics,
+    agent_metadata: AgentMetadata,
     /// Tokio console server
     pub tokio_console_server: Option<console_subscriber::Server>,
     dymension_kaspa_args: Option<DymensionKaspaArgs>,
@@ -136,7 +137,7 @@ impl BaseAgent for Relayer {
     type Metadata = AgentMetadata;
 
     async fn from_settings(
-        _agent_metadata: Self::Metadata,
+        agent_metadata: Self::Metadata,
         settings: Self::Settings,
         core_metrics: Arc<CoreMetrics>,
         agent_metrics: AgentMetrics,
@@ -298,6 +299,7 @@ impl BaseAgent for Relayer {
             agent_metrics,
             chain_metrics,
             runtime_metrics,
+            agent_metadata,
             tokio_console_server: Some(tokio_console_server),
             dymension_kaspa_args: dymension_args,
             origins,
@@ -581,6 +583,7 @@ impl BaseAgent for Relayer {
                     .as_ref()
                     .and_then(|dym_args| dym_args.kas_provider.kaspa_db().cloned()),
             ) // Set kaspa_db to server_builder from dymension_args provider if available
+            .with_metadata(Arc::new(self.agent_metadata.clone()))
             .router();
 
         let server = self

--- a/rust/main/agents/relayer/src/server/mod.rs
+++ b/rust/main/agents/relayer/src/server/mod.rs
@@ -2,12 +2,14 @@ use std::collections::HashMap;
 use std::env;
 use std::sync::Arc;
 
-use axum::Router;
+use axum::{routing::get, Json, Router};
 use derive_new::new;
 use hyperlane_core::HyperlaneDomain;
+use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast::Sender;
 
 use hyperlane_base::db::HyperlaneRocksDB;
+use hyperlane_base::AgentMetadata;
 use hyperlane_core::KaspaDb;
 use tokio::sync::RwLock;
 
@@ -16,6 +18,11 @@ use crate::msg::gas_payment::GasPaymentEnforcer;
 use crate::msg::op_queue::OperationPriorityQueue;
 use crate::msg::pending_message::MessageContext;
 use crate::server::environment_variable::EnvironmentVariableApi;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct VersionResponse {
+    git_sha: String,
+}
 
 pub const ENDPOINT_MESSAGES_QUEUE_SIZE: usize = 100;
 
@@ -45,6 +52,8 @@ pub struct Server {
     prover_syncs: Option<HashMap<u32, Arc<RwLock<MerkleTreeBuilder>>>>,
     #[new(default)]
     kaspa_db: Option<Arc<dyn KaspaDb>>,
+    #[new(default)]
+    metadata: Option<Arc<AgentMetadata>>,
 }
 
 impl Server {
@@ -92,6 +101,11 @@ impl Server {
         self
     }
 
+    pub fn with_metadata(mut self, metadata: Arc<AgentMetadata>) -> Self {
+        self.metadata = Some(metadata);
+        self
+    }
+
     // return a custom router that can be used in combination with other routers
     pub fn router(self) -> Router {
         let mut router = Router::new();
@@ -136,6 +150,17 @@ impl Server {
         if expose_environment_variable_endpoint {
             router = router.merge(EnvironmentVariableApi::new().router());
         }
+
+        if let Some(metadata) = self.metadata {
+            let version_handler = get(move || async move {
+                let response = VersionResponse {
+                    git_sha: metadata.git_sha.clone(),
+                };
+                Json(response)
+            });
+            router = router.route("/version", version_handler);
+        }
+
         router
     }
 }

--- a/rust/main/agents/validator/src/server/mod.rs
+++ b/rust/main/agents/validator/src/server/mod.rs
@@ -5,15 +5,35 @@ pub use eigen_node::EigenNodeApi;
 
 use std::sync::Arc;
 
-use axum::Router;
+use axum::{routing::get, Json, Router};
+use serde::{Deserialize, Serialize};
 
 use hyperlane_base::CoreMetrics;
 use hyperlane_core::HyperlaneDomain;
 
+use crate::ValidatorMetadata;
+
+#[derive(Serialize, Deserialize, Debug)]
+struct VersionResponse {
+    git_sha: String,
+}
+
 /// Returns a vector of validator-specific endpoint routes to be served.
 /// Can be extended with additional routes and feature flags to enable/disable individually.
-pub fn router(origin_chain: HyperlaneDomain, metrics: Arc<CoreMetrics>) -> Router {
+pub fn router(
+    origin_chain: HyperlaneDomain,
+    metrics: Arc<CoreMetrics>,
+    metadata: Arc<ValidatorMetadata>,
+) -> Router {
     let eigen_node_api = EigenNodeApi::new(origin_chain, metrics);
 
-    eigen_node_api.router()
+    let metadata_clone = metadata.clone();
+    let version_handler = get(move || async move {
+        let response = VersionResponse {
+            git_sha: metadata_clone.git_sha.clone(),
+        };
+        Json(response)
+    });
+
+    eigen_node_api.router().route("/version", version_handler)
 }

--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -66,9 +66,9 @@ pub struct Validator {
 }
 
 /// Metadata for `validator`
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 pub struct ValidatorMetadata {
-    git_sha: String,
+    pub git_sha: String,
     rpcs: Vec<H256>,
     allows_public_rpcs: bool,
 }
@@ -210,6 +210,7 @@ impl BaseAgent for Validator {
             .merge(validator_server::router(
                 self.origin_chain.clone(),
                 self.core.metrics.clone(),
+                Arc::new(self.agent_metadata.clone()),
             ))
             .merge(
                 merkle_tree_insertions::list_merkle_tree_insertions::ServerState::new(

--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -37,6 +37,7 @@ use url::Url;
 struct ProcessedWithdrawals {
     fxg: std::sync::Arc<dym_kas_core::withdraw::WithdrawFXG>,
     tx_ids: Vec<RpcTransactionId>,
+    skipped_msgs: Vec<HyperlaneMessage>,
 }
 
 #[derive(Debug, Clone)]
@@ -387,6 +388,12 @@ impl KaspaProvider {
                     }
                 }
 
+                // Include skipped messages (dust/parse errors) with empty tx_id
+                // This prevents them from being marked as failed and retried
+                for msg in processed.skipped_msgs {
+                    result.push((msg, String::new()));
+                }
+
                 self.hack_store_withdrawals_kaspa_tx_for_query(&result);
 
                 Ok(result)
@@ -406,7 +413,7 @@ impl KaspaProvider {
         &self,
         msgs: Vec<HyperlaneMessage>,
     ) -> Result<Option<ProcessedWithdrawals>> {
-        let fxg = match on_new_withdrawals(
+        let (fxg_opt, skipped_msgs) = on_new_withdrawals(
             msgs.clone(),
             self.easy_wallet.clone(),
             self.cosmos_rpc.clone(),
@@ -416,10 +423,24 @@ impl KaspaProvider {
             self.must_relayer_stuff().max_sweep_inputs,
             self.must_relayer_stuff().max_sweep_bundle_bytes,
         )
-        .await?
-        {
+        .await?;
+
+        let fxg = match fxg_opt {
             Some(fxg) => fxg,
-            None => return Ok(None),
+            None => {
+                return Ok(skipped_msgs
+                    .is_empty()
+                    .then_some(())
+                    .map(|_| ProcessedWithdrawals {
+                        fxg: std::sync::Arc::new(dym_kas_core::withdraw::WithdrawFXG::new(
+                            kaspa_wallet_pskt::bundle::Bundle::new(),
+                            vec![],
+                            vec![],
+                        )),
+                        tx_ids: vec![],
+                        skipped_msgs,
+                    }))
+            }
         };
 
         info!("kaspa provider: constructed withdrawal TXs, got withdrawal FXG, now gathering sigs and signing relayer fee");
@@ -443,6 +464,7 @@ impl KaspaProvider {
         Ok(Some(ProcessedWithdrawals {
             fxg: fxg_arc,
             tx_ids,
+            skipped_msgs,
         }))
     }
 

--- a/scripts/check-agent-versions.sh
+++ b/scripts/check-agent-versions.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+HOSTS_FILE="${1:-}"
+TIMEOUT="${2:-5}"
+
+if [ -z "$HOSTS_FILE" ]; then
+    echo "Usage: $0 <hosts-file> [timeout-seconds]"
+    echo ""
+    echo "hosts-file: Text file with one host:port per line"
+    echo "timeout-seconds: Optional timeout for each request (default: 5)"
+    echo ""
+    echo "Example hosts file format:"
+    echo "  validator1.example.com:9090"
+    echo "  relayer1.example.com:9090"
+    echo "  192.168.1.10:9090"
+    exit 1
+fi
+
+if [ ! -f "$HOSTS_FILE" ]; then
+    echo "Error: Hosts file '$HOSTS_FILE' not found"
+    exit 1
+fi
+
+echo "Querying agent versions from hosts in: $HOSTS_FILE"
+echo "Timeout: ${TIMEOUT}s"
+echo "================================================"
+echo ""
+
+while IFS= read -r host || [ -n "$host" ]; do
+    # Skip empty lines and comments
+    if [ -z "$host" ] || [[ "$host" =~ ^[[:space:]]*# ]]; then
+        continue
+    fi
+
+    # Remove leading/trailing whitespace
+    host=$(echo "$host" | xargs)
+
+    # Construct URL
+    url="http://${host}/version"
+
+    # Query the endpoint
+    echo -n "Checking $host ... "
+
+    if response=$(curl -s --max-time "$TIMEOUT" "$url" 2>/dev/null); then
+        # Try to parse JSON response
+        if git_sha=$(echo "$response" | jq -r '.git_sha' 2>/dev/null); then
+            if [ "$git_sha" != "null" ] && [ -n "$git_sha" ]; then
+                echo "OK - version: $git_sha"
+            else
+                echo "ERROR - Invalid response format: $response"
+            fi
+        else
+            echo "ERROR - Failed to parse JSON: $response"
+        fi
+    else
+        echo "ERROR - Failed to connect or timed out"
+    fi
+done < "$HOSTS_FILE"
+
+echo ""
+echo "================================================"
+echo "Version check complete"


### PR DESCRIPTION
## Summary

This PR addresses two issues:

1. **Issue #107**: Add `/version` endpoint to agents for remote version queries
2. **Issue #90**: Fix infinite retry loop for Kaspa withdrawals below dust threshold

## Changes

### Agent Version Endpoint (#107)

- **Validator**: Added `/version` HTTP endpoint that returns `{"git_sha": "<commit-hash>"}`
  - Modified [rust/main/agents/validator/src/server/mod.rs](rust/main/agents/validator/src/server/mod.rs#L23-L38)
  - Updated [rust/main/agents/validator/src/validator.rs](rust/main/agents/validator/src/validator.rs#L69-L71) to expose git_sha

- **Relayer**: Added `/version` HTTP endpoint with same response format
  - Modified [rust/main/agents/relayer/src/server/mod.rs](rust/main/agents/relayer/src/server/mod.rs#L22-L148)
  - Updated [rust/main/agents/relayer/src/relayer.rs](rust/main/agents/relayer/src/relayer.rs#L103)

- **Script**: Created [scripts/check-agent-versions.sh](scripts/check-agent-versions.sh) to query versions from multiple hosts

### Kaspa Dust Threshold Fix (#90)

Fixed infinite retry loop where withdrawal messages below dust threshold were filtered out but marked as failed.

- Modified [dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs](dymension/libs/kaspa/lib/relayer/src/withdraw/hub_to_kaspa.rs#L296-L341) to return skipped messages
- Updated [dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs](dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs#L115-L133) to propagate skipped messages
- Modified [rust/main/chains/dymension-kaspa/src/providers/provider.rs](rust/main/chains/dymension-kaspa/src/providers/provider.rs#L391-L395) to include skipped messages in result

Skipped messages are now marked as "processed" instead of "failed", preventing retry loops and log spam.

## Test Plan

- [ ] Verify `/version` endpoint works on validator
- [ ] Verify `/version` endpoint works on relayer  
- [ ] Test `check-agent-versions.sh` script with test hosts file
- [ ] Verify dust threshold messages are not retried infinitely
- [ ] Check logs for proper "permanently skipped" messages

Closes #107
Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)