### PR TITLE
feat(validator): add version endpoint exposing git hash

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -4043,6 +4043,7 @@ dependencies = [
 name = "dymension-kaspa"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-trait",
  "axum 0.8.4",
  "base64 0.21.7",
@@ -4108,6 +4109,7 @@ dependencies = [
  "tracing-futures",
  "url",
  "validator 0.2.0",
+ "vergen",
 ]
 
 [[package]]

--- a/rust/main/chains/dymension-kaspa/Cargo.toml
+++ b/rust/main/chains/dymension-kaspa/Cargo.toml
@@ -83,3 +83,7 @@ kaspa-utils-tower = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9f
 kaspa-hashes = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
 kaspa-bip32 = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
 kaspa-consensus-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+
+[build-dependencies]
+anyhow = { workspace = true }
+vergen = { version = "8.3.2", features = ["build", "git", "gitcl"] }

--- a/rust/main/chains/dymension-kaspa/build.rs
+++ b/rust/main/chains/dymension-kaspa/build.rs
@@ -1,0 +1,8 @@
+use anyhow::Result;
+use vergen::EmitBuilder;
+
+fn main() -> Result<()> {
+    EmitBuilder::builder().git_sha(false).emit()?;
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Add `/version` GET endpoint to Kaspa validator server that exposes the git commit hash
- Uses existing hyperlane solution via vergen crate to capture git SHA at build time
- Follows the same pattern used in hyperlane-base for git hash generation

## Changes
- Add `build.rs` with vergen to generate `VERGEN_GIT_SHA` environment variable
- Add vergen to build-dependencies in Cargo.toml
- Add `git_sha()` function and `VersionResponse` struct
- Add GET `/version` endpoint handler returning JSON with git SHA
- Register `/version` route in router

## Test plan
- [x] Code compiles successfully (`cargo check -p dymension-kaspa`)
- [x] Pre-commit hooks pass (cargo fmt, gitleaks)
- [ ] Manual testing: Start validator and curl the `/version` endpoint
- [ ] Verify git SHA matches the actual commit hash

Resolves: https://github.com/dymensionxyz/hyperlane-deployments/issues/107

🤖 Generated with [Claude Code](https://claude.com/claude-code)