### PR TITLE
fix(sdk): correct parameter type for validatorsAndThreshold in EvmIsmReader

### DIFF
--- a/typescript/sdk/src/ism/EvmIsmReader.ts
+++ b/typescript/sdk/src/ism/EvmIsmReader.ts
@@ -453,9 +453,7 @@ export class EvmIsmReader extends HyperlaneReader implements IsmReader {
           : IsmType.STORAGE_MESSAGE_ID_MULTISIG;
     }
 
-    const [validators, threshold] = await ism.validatorsAndThreshold(
-      ethers.constants.AddressZero,
-    );
+    const [validators, threshold] = await ism.validatorsAndThreshold('0x');
 
     return {
       address,


### PR DESCRIPTION
## Description

Fixes hanging in `hyperlane warp apply` and `hyperlane warp read` commands.

**Upstream:**
- Issue: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/7499
- PR: https://github.com/hyperlane-xyz/hyperlane-monorepo/pull/7494

## The Fix

**File:** `typescript/sdk/src/ism/EvmIsmReader.ts:457`

```diff
- ethers.constants.AddressZero,
+ '0x',
```

## Testing

**Before fix:**
```bash
timeout 30 hyperlane warp read --chain base --address 0x1397c9c92F128e5E6866b457fac608eE20FD32Ae
# Exit code 124 (timeout) ❌
```

**After fix:**
```bash
hyperlane warp read --chain base --address 0x1397c9c92F128e5E6866b457fac608eE20FD32Ae
# Returns config in seconds ✅
```

**Cast verification:**
```bash
# Shows parameter type matters
cast call 0xf8B38A4e42934c4155de579eBe5448AeDDaFfC64 \
  "validatorsAndThreshold(address)(address[],uint8)" \
  "0x0000000000000000000000000000000000000000" \
  --rpc-url https://mainnet.base.org
# Error: execution reverted ❌

cast call 0xf8B38A4e42934c4155de579eBe5448AeDDaFfC64 \
  "validatorsAndThreshold(bytes)(address[],uint8)" \
  "0x" \
  --rpc-url https://mainnet.base.org
# Returns validators ✅
```

---

Single-line fix based on `main-dym`. Identical fix submitted upstream.