### PR TITLE
feat(kaspa): add DRY websocket reconnection on error

### DIFF
--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/messages.rs
@@ -155,29 +155,34 @@ pub async fn build_withdrawal_fxg(
     }
 
     // Get all the UTXOs for the escrow and the relayer
-    let escrow_inputs = fetch_input_utxos(
-        &relayer.api(),
-        &escrow_public.addr,
-        Some(escrow_public.redeem_script.clone()),
-        escrow_public.n() as u8,
-        relayer.net.network_id,
-    )
-    .await
-    .map_err(|e| eyre::eyre!("Fetch escrow UTXOs: {}", e))?;
+    let escrow_addr = escrow_public.addr.clone();
+    let escrow_redeem = escrow_public.redeem_script.clone();
+    let escrow_n = escrow_public.n() as u8;
+    let network_id = relayer.net.network_id;
+    let escrow_inputs = relayer
+        .rpc_with_reconnect(|api| {
+            let addr = escrow_addr.clone();
+            let redeem = escrow_redeem.clone();
+            async move { fetch_input_utxos(&api, &addr, Some(redeem), escrow_n, network_id).await }
+        })
+        .await
+        .map_err(|e| eyre::eyre!("Fetch escrow UTXOs: {}", e))?;
 
     // Get relayer change address for the withdrawal PSKT change output
     let relayer_address = relayer.account().change_address()?;
 
     // Fetch relayer UTXOs from change address
-    let relayer_inputs = fetch_input_utxos(
-        &relayer.api(),
-        &relayer_address,
-        None,
-        RELAYER_SIG_OP_COUNT,
-        relayer.net.network_id,
-    )
-    .await
-    .map_err(|e| eyre::eyre!("Fetch relayer change address UTXOs: {}", e))?;
+    let relayer_addr_clone = relayer_address.clone();
+    let relayer_inputs =
+        relayer
+            .rpc_with_reconnect(|api| {
+                let addr = relayer_addr_clone.clone();
+                async move {
+                    fetch_input_utxos(&api, &addr, None, RELAYER_SIG_OP_COUNT, network_id).await
+                }
+            })
+            .await
+            .map_err(|e| eyre::eyre!("Fetch relayer change address UTXOs: {}", e))?;
 
     // Early validation of relayer funds available (otherwise it will panic later during PSKT building)
     if relayer_inputs.is_empty() {
@@ -267,7 +272,8 @@ pub async fn build_withdrawal_fxg(
 
     let payload = MessageIDs::from(&final_msgs).to_bytes();
 
-    let feerate = get_normal_bucket_feerate(&relayer.api())
+    let feerate = relayer
+        .rpc_with_reconnect(|api| async move { get_normal_bucket_feerate(&api).await })
         .await
         .map_err(|e| eyre::eyre!("Get normal bucket feerate: {e}"))?;
 

--- a/dymension/libs/kaspa/lib/relayer/src/withdraw/sweep.rs
+++ b/dymension/libs/kaspa/lib/relayer/src/withdraw/sweep.rs
@@ -336,13 +336,13 @@ pub async fn create_sweeping_bundle(
 
     let relayer_address = relayer_wallet.account().change_address()?;
     let feerate = relayer_wallet
-        .api()
-        .get_fee_estimate()
-        .await?
-        .normal_buckets
-        .first()
-        .unwrap()
-        .feerate;
+        .rpc_with_reconnect(|api| async move {
+            api.get_fee_estimate()
+                .await
+                .map(|estimate| estimate.normal_buckets.first().unwrap().feerate)
+                .map_err(|e| eyre::eyre!("{}", e))
+        })
+        .await?;
 
     let mut bundle = Bundle::new();
 

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -549,8 +549,14 @@ where
 
         let utxos = self
             .provider
-            .rpc()
-            .get_utxos_by_addresses(vec![escrow_addr.clone()])
+            .rpc_with_reconnect(|api| {
+                let addr = escrow_addr.clone();
+                async move {
+                    api.get_utxos_by_addresses(vec![addr])
+                        .await
+                        .map_err(|e| eyre::eyre!("{}", e))
+                }
+            })
             .await?;
 
         info!("Queried utxos for escrow address: {:?}", utxos.len());


### PR DESCRIPTION
## Summary
Add on-error reconnection for Kaspa WRPC to handle stale WebSocket connections (#116). This implements a simple DRY approach with ONE reconnection implementation in the wallet library, with the provider simply delegating to it.

## Changes
- Add `reconnect()` and `rpc_with_reconnect()` methods to `EasyKaspaWallet`
- Provider delegates to wallet's reconnection logic (no duplication)
- Update all RPC call sites (7 total) to use `rpc_with_reconnect`:
  - 3 in withdrawal messages flow
  - 1 in sweep flow
  - 2 in balance metrics
  - 1 in transaction submission
- Make `api()` private in wallet to prevent bypassing reconnection
- Remove unused `rpc()` method from provider

## Test plan
- [x] cargo check passes for both dymension/libs/kaspa and rust/main
- [x] cargo fmt applied
- [ ] Test with live Kaspa WRPC connection to verify reconnection works on disconnect

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)