### PR TITLE
fix(rust): resolve clippy warnings in fork-specific code

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -77,7 +77,7 @@ impl KaspaProvider {
         let kaspa_metrics = if let Some(reg) = registry {
             KaspaBridgeMetrics::new(reg).expect("create KaspaBridgeMetrics")
         } else {
-            KaspaBridgeMetrics::new(&prometheus::default_registry())
+            KaspaBridgeMetrics::new(prometheus::default_registry())
                 .expect("create default KaspaBridgeMetrics")
         };
 

--- a/rust/main/chains/dymension-kaspa/src/providers/validators.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/validators.rs
@@ -306,7 +306,7 @@ pub async fn request_validate_new_confirmation(
     host: String,
     conf: &ConfirmationFXG,
 ) -> Result<Signature> {
-    let bz = Bytes::try_from(conf)?;
+    let bz = Bytes::from(conf);
     let res = client
         .post(format!("{}{}", host, ROUTE_VALIDATE_CONFIRMED_WITHDRAWALS))
         .body(bz)

--- a/rust/main/chains/dymension-kaspa/src/validator_server.rs
+++ b/rust/main/chains/dymension-kaspa/src/validator_server.rs
@@ -332,7 +332,7 @@ async fn respond_validate_new_deposits<
         .must_signing()
         .sign_with_fallback(to_sign)
         .await
-        .map_err(|e| AppError(e.into()))?;
+        .map_err(AppError)?;
     info!("validator: signed deposit");
 
     Ok(Json(sig))
@@ -384,7 +384,7 @@ async fn respond_sign_pskts<
     .await
     .map_err(|e| {
         eprintln!("Withdrawal validation and singing failed: {:?}", e);
-        AppError(Report::from(e))
+        AppError(e)
     })?;
 
     Ok(Json(bundle))
@@ -488,7 +488,7 @@ async fn respond_validate_confirmed_withdrawals<
             progress_indication: progress_indication.clone(),
         })
         .await
-        .map_err(|e| AppError(e.into()))?;
+        .map_err(AppError)?;
 
     info!("validator: signed confirmed withdrawal");
 

--- a/rust/main/chains/hyperlane-cosmos/src/lib.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/lib.rs
@@ -18,6 +18,7 @@ mod libs;
 /// CosmosModule/CosmosNative specific modules
 pub mod native;
 mod providers;
+/// Cosmos signer implementations
 pub mod signers;
 mod trait_builder;
 mod utils;

--- a/rust/main/chains/hyperlane-cosmos/src/native/mailbox.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/native/mailbox.rs
@@ -241,7 +241,8 @@ impl CosmosNativeMailbox {
 /// Convert H512 to Cosmos hash format (used by Kaspa bridge)
 pub fn h512_to_cosmos_hash(h: H512) -> Hash {
     let h_256: H256 = h.into();
-    Hash::from_bytes(Algorithm::Sha256, h_256.as_bytes()).unwrap()
+    Hash::from_bytes(Algorithm::Sha256, h_256.as_bytes())
+        .expect("H256 bytes are always valid SHA-256 hash")
 }
 
 /// Extract the last 32 bytes of H512 to create H256

--- a/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/providers/cosmos.rs
@@ -48,6 +48,7 @@ pub trait BuildableQueryClient: Sized + std::fmt::Debug + Sync + Send + 'static 
 #[derive(Debug, Clone)]
 pub struct CosmosProvider<QueryClient> {
     conf: ConnectionConf,
+    /// RPC provider for Cosmos chain
     pub rpc: RpcProvider,
     domain: HyperlaneDomain,
     query: QueryClient,

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -41,7 +41,7 @@ solana-sdk.workspace = true
 static_assertions.workspace = true
 tempfile = { workspace = true, optional = true }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["rt", "macros", "parking_lot"] }
+tokio = { workspace = true, features = ["rt", "macros", "parking_lot", "tracing"] }
 tokio-metrics.workspace = true
 tracing-error.workspace = true
 tracing-futures.workspace = true

--- a/rust/main/hyperlane-core/src/traits/mod.rs
+++ b/rust/main/hyperlane-core/src/traits/mod.rs
@@ -61,11 +61,11 @@ impl From<ethers_core::types::TransactionReceipt> for TxOutcome {
                 .status
                 .map(|status| status.low_u32() == 1)
                 .unwrap_or(false),
-            gas_used: t.gas_used.map(Into::into).unwrap_or(U256::zero()),
+            gas_used: t.gas_used.map(Into::into).unwrap_or_default(),
             gas_price: t
                 .effective_gas_price
                 .and_then(|price| U256::from(price).try_into().ok())
-                .unwrap_or(FixedPointNumber::zero()),
+                .unwrap_or_default(),
         }
     }
 }

--- a/rust/main/hyperlane-core/src/traits/pending_operation.rs
+++ b/rust/main/hyperlane-core/src/traits/pending_operation.rs
@@ -208,8 +208,8 @@ impl Encode for PendingOperationStatus {
         W: Write,
     {
         // Serialize to JSON and write to the writer, to avoid having to implement the encoding manually
-        let serialized = serde_json::to_vec(self)
-            .map_err(|_| std::io::Error::new(std::io::ErrorKind::Other, "Failed to serialize"))?;
+        let serialized =
+            serde_json::to_vec(self).map_err(|_| std::io::Error::other("Failed to serialize"))?;
         writer.write(&serialized)
     }
 }
@@ -222,10 +222,10 @@ impl Decode for PendingOperationStatus {
     {
         // Deserialize from JSON and read from the reader, to avoid having to implement the encoding / decoding manually
         serde_json::from_reader(reader).map_err(|err| {
-            HyperlaneProtocolError::IoError(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Failed to deserialize. Error: {}", err),
-            ))
+            HyperlaneProtocolError::IoError(std::io::Error::other(format!(
+                "Failed to deserialize. Error: {}",
+                err
+            )))
         })
     }
 }


### PR DESCRIPTION
## Summary
Fixed Clippy linter warnings in fork-specific Rust code (files that differ from upstream hyperlane-monorepo).

## Changes
- **hyperlane-core**: Use `std::io::Error::other()` for simpler error construction and `unwrap_or_default()` instead of explicit default values
- **hyperlane-cosmos**: Replace `unwrap()` with `expect()` with descriptive messages, add missing documentation for public API
- **dymension-kaspa**: Remove redundant closures and type conversions in error handling
- **hyperlane-base**: Add tokio "tracing" feature to Cargo.toml (required for task naming)

## Known Issue  
There is a remaining compilation error with `tokio::task::Builder` API that prevents the full Rust workspace from compiling. This appears to be a pre-existing issue that needs separate investigation - the API is being used in several files but isn't available even with the "tracing" feature enabled.

## Test plan
- [x] Cargo fmt passes
- [ ] Cargo clippy passes (blocked by compilation error)
- [ ] Tests pass (blocked by compilation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)