### PR TITLE
claude: refactor(relayer): reduce verbosity of per-validator info logs

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/base_builder.rs
@@ -8,7 +8,7 @@ use futures::{stream, StreamExt};
 use hyperlane_ethereum::Signers;
 use maplit::hashmap;
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use hyperlane_base::{
     cache::{LocalCache, MeteredCache, OptionalCache},
@@ -225,7 +225,7 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
             .iter()
             .zip(storage_locations)
             .filter_map(|(validator, validator_storage_locations)| {
-                info!(hyp_message=?message, ?validator, ?validator_storage_locations, "Validator and its storage locations for message");
+                debug!(hyp_message=?message, ?validator, ?validator_storage_locations, "Validator and its storage locations for message");
                 if validator_storage_locations.is_empty() {
                     // If the validator has not announced any storage locations, we skip it
                     // and log a warning.
@@ -291,7 +291,6 @@ impl BuildsBaseMetadata for BaseMetadataBuilder {
             hyp_message=?message,
             checkpoint_syncers_count = checkpoint_syncers.len(),
             validators_count = validators.len(),
-            ?checkpoint_syncers,
             "Successfully built checkpoint syncers"
         );
 

--- a/rust/main/hyperlane-base/src/types/multisig.rs
+++ b/rust/main/hyperlane-base/src/types/multisig.rs
@@ -65,7 +65,7 @@ impl MultisigCheckpointSyncer {
         for (validator, latest_index) in validator_index_results {
             match latest_index {
                 Ok(Some(index)) => {
-                    info!(?validator, ?index, "Validator returned latest index");
+                    debug!(?validator, ?index, "Validator returned latest index");
                     latest_indices.insert(*validator, Some(index));
                 }
                 Ok(None) => {


### PR DESCRIPTION
## Summary
Reduces log verbosity by downgrading repetitive per-validator logs from info to debug level:

- **base_builder.rs:228**: Validator storage locations log (fires per validator per message)
- **multisig.rs:68**: Successful validator index returns (fires per validator per message)
- **base_builder.rs:294**: Removed verbose `?checkpoint_syncers` field from success log

## Problem
The INFO logs added in commits f4c6dad8a, 1d5b83e3f, and df598e747 were useful for debugging specific issues, but some are too verbose for production use:

1. With 9 validators and many messages, these per-validator logs spam the output
2. The `?checkpoint_syncers` field dumps the entire checkpoint syncer map on every message

## Solution
- Downgrade high-frequency success path logs to `debug!` level
- Keep error/failure condition logs at `info!` level (they're already infrequent)
- Remove verbose field from success log while keeping useful counts

## Testing
- ✅ `cargo check --workspace` passes
- ✅ `cargo fmt` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)