### PR TITLE
refactor(ethereum): change rate limit log level from info to debug

### DIFF
--- a/rust/main/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
+++ b/rust/main/chains/hyperlane-ethereum/src/rpc_clients/mod.rs
@@ -1,5 +1,5 @@
 use ethers::providers::HttpClientError;
-use tracing::{error, info, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 pub use self::{fallback::*, provider::*, retrying::*, trait_builder::*};
 pub use error::decode_revert_reason;
@@ -55,7 +55,7 @@ fn categorize_client_response<R>(
         }
         Err(SerdeJson { err, text }) => {
             if text.contains("429") {
-                warn!(provider_host, error=%err, text, "Received rate limit request SerdeJson error in http provider");
+                debug!(provider_host, error=%err, text, "Received rate limit request SerdeJson error in http provider");
                 RateLimitErr(SerdeJson { err, text })
             } else {
                 warn!(provider_host, error=%err, text, "SerdeJson error in http provider");
@@ -69,7 +69,7 @@ fn categorize_client_response<R>(
                 || msg.contains("rate limit")
                 || msg.contains("too many requests")
             {
-                info!(provider_host, error=%e, "Received rate limit request JsonRpcError in http provider");
+                debug!(provider_host, error=%e, "Received rate limit request JsonRpcError in http provider");
                 RateLimitErr(JsonRpcError(e))
             } else if METHODS_TO_NOT_RETRY.contains(&method)
                 || (METHOD_TO_NOT_RETRY_WHEN_NOT_SUPPORTED.contains(&method)


### PR DESCRIPTION
## Summary
- Change `info!` to `debug!` for rate limit logging in `hyperlane-ethereum/src/rpc_clients/mod.rs`
- Rate limiting is expected when using public RPC providers
- Applied to both `JsonRpcError` and `SerdeJson` rate limit detection paths for consistency

## Context
Analysis of production logs showed high-frequency INFO logs from rate limit responses. When using public RPCs, rate limiting is expected behavior and should not clutter production logs.

Closes dymensionxyz/hyperlane-deployments#134

## Test plan
- [x] `cargo check -p hyperlane-ethereum` passes
- [x] Reviewed by rust-reviewer agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)