### PR TITLE
chore(kaspa): remove unused hyperlane-core dep from hardcode

### DIFF
--- a/dymension/libs/kaspa/Cargo.lock
+++ b/dymension/libs/kaspa/Cargo.lock
@@ -4072,7 +4072,6 @@ dependencies = [
 name = "hardcode"
 version = "0.2.0"
 dependencies = [
- "hyperlane-core",
  "kaspa-addresses",
  "kaspa-consensus-core",
  "openapi",

--- a/dymension/libs/kaspa/lib/hardcode/Cargo.toml
+++ b/dymension/libs/kaspa/lib/hardcode/Cargo.toml
@@ -7,6 +7,5 @@ edition = "2021"
 kaspa-addresses = { workspace = true }
 kaspa-consensus-core = { workspace = true }
 api-rs = { path = "../../lib/api", package = "openapi" }
-hyperlane-core = { path = "../../../../../rust/main/hyperlane-core" }
 reqwest-middleware = "0.4"
 reqwest = { workspace = true }


### PR DESCRIPTION
## Summary

- Removes unused `hyperlane-core` dependency from the `hardcode` crate in `libs/kaspa`
- Reduces unnecessary coupling between `libs/kaspa` and `rust/main`
- Verified the crate still builds correctly after removal

## Details

The `hardcode` crate had `hyperlane-core` listed as a dependency but doesn't actually import or use anything from it. This change cleans up the dependency graph and makes the kaspa libs more independent.

Related to dymensionxyz/hyperlane-deployments#140

## Test plan

- [x] `cargo check -p hardcode` passes
- [x] No references to hyperlane types in hardcode source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)