### PR TITLE
refactor(kaspa): move HL domain constants to rust/main

### DIFF
--- a/dymension/libs/kaspa/Cargo.lock
+++ b/dymension/libs/kaspa/Cargo.lock
@@ -1914,6 +1914,7 @@ dependencies = [
  "borsh 1.5.7",
  "bytes",
  "clap",
+ "dymension-kaspa-hl-constants",
  "eyre",
  "governor",
  "hardcode",
@@ -2849,6 +2850,10 @@ dependencies = [
  "tracing",
  "validator",
 ]
+
+[[package]]
+name = "dymension-kaspa-hl-constants"
+version = "0.1.0"
 
 [[package]]
 name = "dyn-clone"
@@ -9982,6 +9987,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.4",
  "core",
+ "dymension-kaspa-hl-constants",
  "ethers",
  "eyre",
  "hardcode",

--- a/dymension/libs/kaspa/lib/core/Cargo.toml
+++ b/dymension/libs/kaspa/lib/core/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 hardcode = { path = "../hardcode" }
+dymension-kaspa-hl-constants = { path = "../../../../../rust/main/chains/dymension-kaspa-hl-constants" }
 hex = { workspace = true }
 kaspa-addresses = { workspace = true }
 kaspa-consensus-core = { workspace = true }

--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -310,7 +310,7 @@ fn has_valid_hyperlane_payload(tx: &TxModel, domain_kas: u32) -> bool {
 mod tests {
     use super::*;
     use crate::message::ParsedHL;
-    use hardcode::hl::{HL_DOMAIN_KASPA_TEST10, HL_DOMAIN_KASPA_TEST10_LEGACY};
+    use dymension_kaspa_hl_constants::{HL_DOMAIN_KASPA_TEST10, HL_DOMAIN_KASPA_TEST10_LEGACY};
 
     #[tokio::test]
     #[ignore = "dont hit real api"]

--- a/dymension/libs/kaspa/lib/core/src/api/test.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/test.rs
@@ -137,7 +137,7 @@ mod tests {
             .get_deposits_by_address(
                 Some(1751299515650),
                 address,
-                hardcode::hl::HL_DOMAIN_KASPA_TEST10,
+                dymension_kaspa_hl_constants::HL_DOMAIN_KASPA_TEST10,
             )
             .await;
 

--- a/dymension/libs/kaspa/lib/hardcode/src/lib.rs
+++ b/dymension/libs/kaspa/lib/hardcode/src/lib.rs
@@ -1,3 +1,2 @@
 pub mod e2e;
-pub mod hl;
 pub mod tx;

--- a/dymension/libs/kaspa/lib/validator/Cargo.toml
+++ b/dymension/libs/kaspa/lib/validator/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 corelib = { path = "../core", package = "core" }
 api-rs = { path = "../api", package = "openapi" }
 hardcode = { path = "../hardcode", package = "hardcode" }
+dymension-kaspa-hl-constants = { path = "../../../../../rust/main/chains/dymension-kaspa-hl-constants" }
 kaspa-addresses = { workspace = true }
 kaspa-consensus-core = { workspace = true }
 kaspa-core = { workspace = true }

--- a/dymension/libs/kaspa/lib/validator/src/deposit.rs
+++ b/dymension/libs/kaspa/lib/validator/src/deposit.rs
@@ -5,7 +5,7 @@ use corelib::finality::is_safe_against_reorg;
 use corelib::message::{add_kaspa_metadata_hl_messsage, ParsedHL};
 use corelib::wallet::NetworkInfo;
 use eyre::Result;
-use hardcode::hl::ALLOWED_HL_MESSAGE_VERSION;
+use dymension_kaspa_hl_constants::ALLOWED_HL_MESSAGE_VERSION;
 use hyperlane_core::HyperlaneMessage;
 use hyperlane_core::H256;
 use hyperlane_core::U256;

--- a/dymension/libs/kaspa/lib/validator/src/withdraw.rs
+++ b/dymension/libs/kaspa/lib/validator/src/withdraw.rs
@@ -7,7 +7,7 @@ use corelib::util;
 use corelib::util::{get_recipient_script_pubkey, is_valid_sighash_type};
 use corelib::withdraw::{filter_pending_withdrawals, WithdrawFXG};
 use eyre::Result;
-use hardcode::hl::ALLOWED_HL_MESSAGE_VERSION;
+use dymension_kaspa_hl_constants::ALLOWED_HL_MESSAGE_VERSION;
 use hex::ToHex;
 use hyperlane_core::{Decode, HyperlaneMessage, H256};
 use hyperlane_cosmos::native::ModuleQueryClient;

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -2824,6 +2824,7 @@ dependencies = [
  "borsh 1.5.1",
  "bytes",
  "clap 4.5.41",
+ "dymension-kaspa-hl-constants",
  "eyre",
  "governor",
  "hardcode",
@@ -4054,9 +4055,9 @@ dependencies = [
  "crypto",
  "derive-new",
  "dym-kas-kms",
+ "dymension-kaspa-hl-constants",
  "eyre",
  "futures",
- "hardcode",
  "hex 0.4.3",
  "http 1.2.0",
  "hyper 0.14.30",
@@ -4111,6 +4112,10 @@ dependencies = [
  "validator 0.2.0",
  "vergen",
 ]
+
+[[package]]
+name = "dymension-kaspa-hl-constants"
+version = "0.1.0"
 
 [[package]]
 name = "dyn-clone"
@@ -15960,6 +15965,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.4",
  "core",
+ "dymension-kaspa-hl-constants",
  "ethers 2.0.14",
  "eyre",
  "hardcode",

--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -8,6 +8,7 @@ members = [
   "applications/hyperlane-warp-route",
   "chains/hyperlane-cosmos",
   "chains/dymension-kaspa",
+  "chains/dymension-kaspa-hl-constants",
   "chains/hyperlane-ethereum",
   "chains/hyperlane-fuel",
   "chains/hyperlane-radix",

--- a/rust/main/chains/dymension-kaspa-hl-constants/Cargo.toml
+++ b/rust/main/chains/dymension-kaspa-hl-constants/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dymension-kaspa-hl-constants"
+documentation = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license-file = { workspace = true }
+publish = { workspace = true }
+version = { workspace = true }
+
+[dependencies]
+# Intentionally no dependencies to avoid circular dependency issues

--- a/rust/main/chains/dymension-kaspa-hl-constants/src/lib.rs
+++ b/rust/main/chains/dymension-kaspa-hl-constants/src/lib.rs
@@ -1,3 +1,8 @@
+//! Hyperlane domain ID constants for Kaspa and Dymension networks.
+//!
+//! These constants define the domain IDs used in the Hyperlane protocol
+//! for routing messages between Kaspa and Dymension networks.
+
 pub const ALLOWED_HL_MESSAGE_VERSION: u8 = 3;
 
 pub const HL_DOMAIN_DYM_MAINNET: u32 = 1570310961; // NOTE: was patched to this value just before mainnet release. The old value did not do modulo on derivation.

--- a/rust/main/chains/dymension-kaspa/Cargo.toml
+++ b/rust/main/chains/dymension-kaspa/Cargo.toml
@@ -53,8 +53,8 @@ dym-kas-validator = { path = "../../../../dymension/libs/kaspa/lib/validator", p
 dym-kas-relayer = { path = "../../../../dymension/libs/kaspa/lib/relayer" , package="relayer"}
 dym-kas-core = { path = "../../../../dymension/libs/kaspa/lib/core" , package="core"}
 dym-kas-api = { path = "../../../../dymension/libs/kaspa/lib/api" , package="openapi"}
-dym-kas-hardcode = { path = "../../../../dymension/libs/kaspa/lib/hardcode" , package="hardcode"}
 dym-kas-kms = { path = "../../../../dymension/libs/kaspa/lib/kms", package="dym-kas-kms"}
+dymension-kaspa-hl-constants = { path = "../dymension-kaspa-hl-constants" }
 eyre = { workspace = true }
 bytes = { workspace = true }
 prometheus = { workspace = true }

--- a/rust/main/chains/dymension-kaspa/src/lib.rs
+++ b/rust/main/chains/dymension-kaspa/src/lib.rs
@@ -25,6 +25,7 @@ mod withdrawal_utils;
 pub use dym_kas_core;
 pub use dym_kas_relayer;
 pub use dym_kas_validator;
+pub use dymension_kaspa_hl_constants as hl_domains;
 
 pub use util::*;
 

--- a/rust/main/chains/dymension-kaspa/src/util.rs
+++ b/rust/main/chains/dymension-kaspa/src/util.rs
@@ -1,7 +1,7 @@
 use hyperlane_core::{HyperlaneDomain, HyperlaneDomainProtocol};
 
 use dym_kas_core::wallet::Network;
-use dym_kas_hardcode::hl::{
+use dymension_kaspa_hl_constants::{
     HL_DOMAIN_DYM_LOCAL, HL_DOMAIN_DYM_MAINNET, HL_DOMAIN_DYM_PLAYGROUND_202507,
     HL_DOMAIN_DYM_PLAYGROUND_202507_LEGACY, HL_DOMAIN_DYM_PLAYGROUND_202509,
     HL_DOMAIN_DYM_TESTNET_BLUMBUS, HL_DOMAIN_KASPA_MAINNET, HL_DOMAIN_KASPA_TEST10,


### PR DESCRIPTION
## Summary

Move Hyperlane domain ID constants from `libs/kaspa/lib/hardcode/src/hl.rs` to a new dedicated crate `rust/main/chains/dymension-kaspa-hl-constants`.

This refactoring:
- Makes the `hardcode` crate purely Kaspa-focused by removing HL-specific constants
- Places HL integration constants in the `rust/main` workspace where they logically belong
- Breaks circular dependencies by creating a minimal constants-only crate with zero dependencies
- Updates all imports across both `rust/main` and `dymension/libs/kaspa` workspaces

## Changes

- Created new `dymension-kaspa-hl-constants` crate in `rust/main/chains/`
- Moved all HL domain constants from `hardcode::hl` to the new crate
- Updated `dymension-kaspa` to re-export constants from `dymension-kaspa-hl-constants`
- Updated `libs/kaspa/lib/core` and `libs/kaspa/lib/validator` to import from new crate
- Removed `dymension/libs/kaspa/lib/hardcode/src/hl.rs`
- Removed `pub mod hl;` from hardcode lib.rs

## Architecture

The new `dymension-kaspa-hl-constants` crate:
- Has zero dependencies (avoiding circular dependency issues)
- Is imported by both `dymension-kaspa` (rust/main) and libs/kaspa crates (core, validator)
- Contains only constant definitions for HL domain IDs

Dependency flow:
- `dymension-kaspa-hl-constants` ← (no dependencies)
- `dymension-kaspa` ← depends on `dym-kas-core` and `dymension-kaspa-hl-constants`
- `dym-kas-core` ← depends on `dymension-kaspa-hl-constants`
- No circular dependencies!

## Test plan

- [x] `cargo check -p dymension-kaspa` from `rust/main` - passes
- [x] `cargo check` from `dymension/libs/kaspa` - passes

## Related

Relates to issue #140 in hyperlane-deployments repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)