### PR TITLE
fix(cosmos): add MessageIdMultisigIsm support in validators_and_threshold

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/native/ism.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/native/ism.rs
@@ -128,6 +128,16 @@ impl MultisigIsm for CosmosNativeIsm {
                     .collect::<Result<Vec<_>, _>>()?;
                 Ok((validators, ism.threshold as u8))
             }
+            t if t == MessageIdMultisigIsm::type_url() => {
+                let ism = MessageIdMultisigIsm::decode(ism.value.as_slice())
+                    .map_err(HyperlaneCosmosError::from)?;
+                let validators = ism
+                    .validators
+                    .iter()
+                    .map(|v| H160::from_str(v).map(H256::from))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok((validators, ism.threshold as u8))
+            }
             _ => Err(ChainCommunicationError::from_other_str(&format!(
                 "ISM {:?} not a multi sig ism",
                 self.address


### PR DESCRIPTION
## Summary

The `CosmosNativeIsm::validators_and_threshold()` function only handled `MerkleRootMultisigIsm` but not `MessageIdMultisigIsm`, even though `module_type()` correctly recognizes both ISM types.

This caused the relayer to fail with `ISM not a multi sig ism` error when processing messages on Cosmos chains configured with `MessageIdMultisigIsm`.

### Changes
- Add handling for `MessageIdMultisigIsm` in `validators_and_threshold()` to match the existing `MerkleRootMultisigIsm` case

### Related
- Fixes: https://github.com/dymensionxyz/hyperlane-deployments/issues/141

## Test plan
- [ ] Build relayer with this change
- [ ] Deploy to testnet relayer
- [ ] Verify Sepolia → Dymension transfers work with MessageIdMultisigISM

🤖 Generated with [Claude Code](https://claude.com/claude-code)