### PR TITLE
chore(kaspa): centralize kaspa deps in workspace

### DIFF
--- a/rust/main/Cargo.toml
+++ b/rust/main/Cargo.toml
@@ -203,6 +203,21 @@ sbor = { git = "https://github.com/hyperlane-xyz/radixdlt-scrypto.git", branch =
 ] }
 hyperlane-cosmos-rs = { package = "hyperlane-cosmos-dymension-rs", git = "https://github.com/dymensionxyz/hyperlane-cosmos-rs", rev = "4cde36b" }
 
+## Kaspa dependencies
+kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-wallet-pskt = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-wrpc-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-addresses = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-wallet-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-wallet-keys = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-rpc-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-grpc-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-utils-tower = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-hashes = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-bip32 = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-consensus-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
 
 ## TODO: remove this
 cosmwasm-schema = "2.2.0"

--- a/rust/main/chains/dymension-kaspa/Cargo.toml
+++ b/rust/main/chains/dymension-kaspa/Cargo.toml
@@ -69,20 +69,20 @@ hyperlane-cosmos-rs = { package = "hyperlane-cosmos-dymension-rs", git = "https:
 
 # Kaspa
 
-kaspa-consensus-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-txscript = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-wallet-pskt = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-wrpc-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-addresses = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-wallet-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-wallet-keys = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-rpc-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-core = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-grpc-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-utils-tower = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-hashes = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-bip32 = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
-kaspa-consensus-client = { git = "https://github.com/kaspanet/rusty-kaspa", rev = "9ff5d0f" }
+kaspa-consensus-core = { workspace = true }
+kaspa-txscript = { workspace = true }
+kaspa-wallet-pskt = { workspace = true }
+kaspa-wrpc-client = { workspace = true }
+kaspa-addresses = { workspace = true }
+kaspa-wallet-core = { workspace = true }
+kaspa-wallet-keys = { workspace = true }
+kaspa-rpc-core = { workspace = true }
+kaspa-core = { workspace = true }
+kaspa-grpc-client = { workspace = true }
+kaspa-utils-tower = { workspace = true }
+kaspa-hashes = { workspace = true }
+kaspa-bip32 = { workspace = true }
+kaspa-consensus-client = { workspace = true }
 
 [build-dependencies]
 anyhow = { workspace = true }


### PR DESCRIPTION
## Summary
- Moves kaspa-* dependencies from `dymension-kaspa` crate to `rust/main` workspace dependencies
- Eliminates duplication between crate and workspace definitions
- All 14 kaspa dependencies now use `workspace = true` syntax in dymension-kaspa

## Motivation
Currently kaspa dependencies are defined twice:
1. In `dymension/libs/kaspa/Cargo.toml` (separate workspace)
2. In `rust/main/chains/dymension-kaspa/Cargo.toml` (duplicate definitions)

This duplication creates risk of version drift and adds maintenance burden. By centralizing in the rust/main workspace, we ensure single source of truth for the dymension-kaspa crate.

Note: The libs/kaspa workspace retains its own definitions as Cargo doesn't support cross-workspace dependency inheritance.

## Changes
### rust/main/Cargo.toml
Added 14 kaspa dependencies to [workspace.dependencies]:
- kaspa-consensus-core, kaspa-txscript, kaspa-wallet-pskt, kaspa-wrpc-client
- kaspa-addresses, kaspa-wallet-core, kaspa-wallet-keys, kaspa-rpc-core
- kaspa-core, kaspa-grpc-client, kaspa-utils-tower, kaspa-hashes
- kaspa-bip32, kaspa-consensus-client

All pointing to git rev `9ff5d0f`

### rust/main/chains/dymension-kaspa/Cargo.toml
Changed all kaspa dependencies to use `workspace = true`

## Test plan
- [x] `cargo check -p dymension-kaspa` passes in rust/main workspace
- [x] `cargo check` passes in libs/kaspa workspace (unaffected)
- [x] No behavioral changes, purely internal refactoring

Related to dymensionxyz/hyperlane-deployments#140

🤖 Generated with [Claude Code](https://claude.com/claude-code)