### PR TITLE
refactor(kaspa): expose message module as hl_message in dymension-kaspa

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6168,7 +6168,6 @@ dependencies = [
 name = "hardcode"
 version = "0.2.0"
 dependencies = [
- "hyperlane-core",
  "kaspa-addresses",
  "kaspa-consensus-core",
  "openapi",

--- a/rust/main/chains/dymension-kaspa/src/lib.rs
+++ b/rust/main/chains/dymension-kaspa/src/lib.rs
@@ -27,6 +27,9 @@ pub use dym_kas_relayer;
 pub use dym_kas_validator;
 pub use dymension_kaspa_hl_constants as hl_domains;
 
+// Re-export message module from dym_kas_core as hl_message for semantic clarity
+pub use dym_kas_core::message as hl_message;
+
 pub use util::*;
 
 mod validator_server;

--- a/rust/main/chains/dymension-kaspa/src/withdrawal_utils.rs
+++ b/rust/main/chains/dymension-kaspa/src/withdrawal_utils.rs
@@ -19,7 +19,7 @@ pub fn record_withdrawal_batch_metrics(
                 metrics.record_withdrawal_batch_size(messages.len() as u64);
             }
             for msg in messages {
-                if let Some(amount) = dym_kas_core::message::parse_withdrawal_amount(msg) {
+                if let Some(amount) = crate::hl_message::parse_withdrawal_amount(msg) {
                     let message_id = format!("{:?}", msg.id());
                     metrics.record_withdrawal_initiated(&message_id, amount);
                 }
@@ -27,7 +27,7 @@ pub fn record_withdrawal_batch_metrics(
         }
         WithdrawalStage::Processed => {
             for msg in messages {
-                if let Some(amount) = dym_kas_core::message::parse_withdrawal_amount(msg) {
+                if let Some(amount) = crate::hl_message::parse_withdrawal_amount(msg) {
                     let message_id = format!("{:?}", msg.id());
                     metrics.record_withdrawal_processed(&message_id, amount);
                 }
@@ -35,7 +35,7 @@ pub fn record_withdrawal_batch_metrics(
         }
         WithdrawalStage::Failed => {
             for msg in messages {
-                if let Some(amount) = dym_kas_core::message::parse_withdrawal_amount(msg) {
+                if let Some(amount) = crate::hl_message::parse_withdrawal_amount(msg) {
                     let message_id = format!("{:?}", msg.id());
                     metrics.record_withdrawal_failed(&message_id, amount);
                 }

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -1,5 +1,5 @@
 use crate::contract_sync::cursors::Indexable;
-use dym_kas_core::message::add_kaspa_metadata_hl_messsage;
+use dymension_kaspa::hl_message::add_kaspa_metadata_hl_messsage;
 use dym_kas_core::{
     confirmation::ConfirmationFXG, deposit::DepositFXG, finality::is_safe_against_reorg,
 };
@@ -215,7 +215,7 @@ where
         deposit: &Deposit,
         escrow_address: &str,
     ) -> Result<(hyperlane_core::HyperlaneMessage, u64, usize), eyre::Error> {
-        use dym_kas_core::message::ParsedHL;
+        use dymension_kaspa::hl_message::ParsedHL;
 
         let payload = deposit
             .payload


### PR DESCRIPTION
## Summary

Re-export `dym_kas_core::message` as `dymension_kaspa::hl_message` to create semantic separation between pure Kaspa libs and Hyperlane integration layer.

## Changes

- Add `pub use dym_kas_core::message as hl_message;` in `rust/main/chains/dymension-kaspa/src/lib.rs`
- Update imports in `rust/main/` to use `dymension_kaspa::hl_message` instead of `dym_kas_core::message`:
  - `rust/main/chains/dymension-kaspa/src/withdrawal_utils.rs`
  - `rust/main/hyperlane-base/src/kas_hack/logic_loop.rs`
- Files in `dymension/libs/kaspa` continue using `corelib::message` (no circular dependencies)

## Architecture

This approach maintains the existing dependency structure while providing clear naming:

```
dymension-kaspa (rust/main)
  ├─ depends on: dym_kas_core, dym_kas_relayer, dym_kas_validator
  └─ re-exports: dym_kas_core::message as hl_message
  
libs/kaspa (dymension/libs/kaspa)
  └─ uses: corelib::message (internal reference)
```

The message parsing utilities remain physically in `libs/kaspa/lib/core/src/message.rs` but are semantically exposed as Hyperlane-specific functionality through the `hl_message` module name.

## Test plan

- [x] `cargo check -p dymension-kaspa` from `rust/main` - passes
- [x] `cargo check` from `dymension/libs/kaspa` - passes
- [x] All imports updated correctly
- [x] No circular dependencies

## Related

Related to dymensionxyz/hyperlane-deployments#140

🤖 Generated with [Claude Code](https://claude.com/claude-code)