### PR TITLE
fix(kaspa): update imports after bridge crate split

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -6740,6 +6740,7 @@ dependencies = [
  "axum 0.8.4",
  "backtrace",
  "backtrace-oneline",
+ "bridge",
  "bs58 0.5.1",
  "chrono",
  "color-eyre",

--- a/rust/main/hyperlane-base/Cargo.toml
+++ b/rust/main/hyperlane-base/Cargo.toml
@@ -71,6 +71,7 @@ hyperlane-sealevel = { path = "../chains/hyperlane-sealevel" }
 hyperlane-radix = { path = "../chains/hyperlane-radix" }
 
 dym_kas_core = { path = "../../../dymension/libs/kaspa/lib/core" , package="core"}
+dym_kas_bridge = { path = "../../../dymension/libs/kaspa/lib/bridge" , package="bridge"}
 dym_kas_hardcode = { path = "../../../dymension/libs/kaspa/lib/hardcode" , package="hardcode"}
 api-rs = { path = "../../../dymension/libs/kaspa/lib/api", package = "openapi" }
 dym_kas_relayer = { path = "../../../dymension/libs/kaspa/lib/relayer" , package="relayer"}

--- a/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/logic_loop.rs
@@ -1,8 +1,7 @@
 use crate::contract_sync::cursors::Indexable;
 use dymension_kaspa::hl_message::add_kaspa_metadata_hl_messsage;
-use dym_kas_core::{
-    confirmation::ConfirmationFXG, deposit::DepositFXG, finality::is_safe_against_reorg,
-};
+use dym_kas_bridge::{confirmation::ConfirmationFXG, deposit::DepositFXG};
+use dym_kas_core::finality::is_safe_against_reorg;
 use dym_kas_relayer::confirm::expensive_trace_transactions;
 use dym_kas_relayer::deposit::{build_deposit_fxg, check_deposit_finality, KaspaTxError};
 use dymension_kaspa::{Deposit, KaspaProvider};


### PR DESCRIPTION
## Summary
- Fixes broken build in rust/main after PR #389 merged
- Updates `hyperlane-base` to import `ConfirmationFXG` and `DepositFXG` from `dym_kas_bridge` instead of `dym_kas_core`
- Adds `dym_kas_bridge` dependency to `hyperlane-base/Cargo.toml`

## Test plan
- [x] `cargo build --release` in rust/main passes
- [x] `cargo build --release` in libs/kaspa passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)