### PR TITLE
claude: docs: update kaspa-tools path after move

### DIFF
--- a/dymension/tests/kaspa_hub_test_kas/commands.sh
+++ b/dymension/tests/kaspa_hub_test_kas/commands.sh
@@ -28,8 +28,8 @@
 #### Step 1. Setup escrow
 #### Create hyperlane validators keys and addresses, and kaspa escrow keys and address, seed the escrow
 
-# in libs/kaspa/tooling
-cargo run validator-with-escrow
+# in rust/main
+cargo run -p kaspa-tools -- validator create local
 Validator infos: {
   "validator_ism_addr": "0x172ed756c7c04f6e5370f9fc181f85b7779643eb",
   "validator_ism_priv_key": "a4d1c634e1b8cde0fc53013dfc62e1789535b59d15b0bbf4c8fbd2d4e79bc132",

--- a/dymension/validators/bridge/README_bridge_kaspa.md
+++ b/dymension/validators/bridge/README_bridge_kaspa.md
@@ -38,7 +38,7 @@ BOTH methods have the same structure
 
 ### PHASE 1: KEY GENERATION AND SHARING
 
-In `hyperlane-monorepo/dymension/libs/kaspa/tooling` do `cargo run validator create local -o kaspa-bridge-keys.json`.
+In `hyperlane-monorepo/rust/main` do `cargo run -p kaspa-tools -- validator create local -o kaspa-bridge-keys.json`.
 
 It outputs (to file) something like
 
@@ -287,9 +287,9 @@ mkdir -p ~/kaspa/{db,config,logs}
 echo '<kaspa_kms_key_arn>' > ~/kaspa/kaspa-kms-key-arn
 echo '<kaspa_secret_path>' > ~/kaspa/kaspa-secret-path
 
-cd ~/hyperlane-monorepo/dymension/libs/kaspa/tooling
+cd ~/hyperlane-monorepo/rust/main
 
-cargo run validator create aws --path $(cat ~/kaspa/kaspa-secret-path) --kms-key-id $(cat ~/kaspa/kaspa-kms-key-arn)
+cargo run -p kaspa-tools -- validator create aws --path $(cat ~/kaspa/kaspa-secret-path) --kms-key-id $(cat ~/kaspa/kaspa-kms-key-arn)
 
 echo '<kaspa_dym_kms_key_arn>' > ~/kaspa/dym-kms-key-arn
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect kaspa-tools new location after PR #393.

### Changes

- `README_bridge_kaspa.md`: Update tool invocation commands
- `commands.sh`: Update test script comments

### New tool usage

**Old (no longer works):**
```bash
cd hyperlane-monorepo/dymension/libs/kaspa/tooling
cargo run validator create local -o kaspa-bridge-keys.json
```

**New:**
```bash
cd hyperlane-monorepo/rust/main
cargo run -p kaspa-tools -- validator create local -o kaspa-bridge-keys.json
```

## Test plan

- [x] Verified documentation paths are correct
- [x] Commands syntax is valid for cargo workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)