### PR TITLE
chore(kaspa): fix compiler warnings and remove unused imports

### DIFF
--- a/dymension/libs/kaspa/lib/core/src/api/client.rs
+++ b/dymension/libs/kaspa/lib/core/src/api/client.rs
@@ -110,7 +110,7 @@ impl HttpClient {
         &self,
         from_unix_time: Option<i64>,
         address: &str,
-        domain_kas: u32,
+        _domain_kas: u32,
     ) -> Result<Vec<Deposit>> {
         /*
         https://api-tn10.kaspa.org/docs#/Kaspa%20addresses/get_full_transactions_for_address_page_addresses__kaspaAddress__full_transactions_page_get

--- a/dymension/libs/kaspa/lib/core/src/balance.rs
+++ b/dymension/libs/kaspa/lib/core/src/balance.rs
@@ -2,8 +2,6 @@ use eyre::Result;
 use kaspa_addresses::Address;
 use kaspa_rpc_core::api::rpc::RpcApi;
 use kaspa_wallet_core::error::Error;
-use kaspa_wallet_core::prelude::*;
-use std::sync::Arc;
 use tracing::info;
 
 pub async fn check_balance<T: RpcApi + ?Sized>(

--- a/rust/main/chains/dymension-kaspa/src/ops/user/deposit.rs
+++ b/rust/main/chains/dymension-kaspa/src/ops/user/deposit.rs
@@ -1,45 +1,9 @@
-#![allow(unused)] // TODO: remove
-
-use crate::ops::deposit::*;
-use bytes::Bytes;
-use dym_kas_api::apis::configuration;
-use dym_kas_core::api::client::Deposit;
-use dym_kas_core::balance::*;
-use dym_kas_core::escrow::*;
-use dym_kas_core::wallet::*;
-use dym_kas_hardcode::e2e::*;
-use hex;
-use hyperlane_core::{Decode, Encode, HyperlaneMessage, H256, U256};
-use hyperlane_warp_route::TokenMessage;
-use kaspa_addresses::Address;
-use kaspa_consensus_core::{
-    constants::TX_VERSION,
-    sign::sign,
-    subnets::SUBNETWORK_ID_NATIVE,
-    tx::{
-        MutableTransaction, ScriptPublicKey, Transaction, TransactionInput, TransactionOutpoint,
-        TransactionOutput, UtxoEntry,
-    },
-};
-use kaspa_core::info;
-use kaspa_grpc_client::GrpcClient;
-use kaspa_wallet_core::api::{AccountsSendRequest, WalletApi};
-use kaspa_wallet_core::error::Error as KaspaError;
-use kaspa_wallet_core::tx::Fees;
-use std::error::Error;
-use std::sync::Arc;
-
-use kaspa_wallet_core::prelude::*;
-use kaspa_wallet_pskt::prelude::*; // Import the prelude for easy access to traits/structs
-
-use kaspa_bip32::secp256k1::{rand::thread_rng, Keypair};
-
-use dym_kas_api::apis::kaspa_transactions_api::{
-    get_transaction_transactions_transaction_id_get,
-    GetTransactionTransactionsTransactionIdGetParams,
-};
 use eyre::Result;
-use kaspa_rpc_core::api::rpc::RpcApi;
+use kaspa_addresses::Address;
+use kaspa_wallet_core::error::Error as KaspaError;
+use kaspa_wallet_core::prelude::*;
+use kaspa_wallet_core::tx::Fees;
+use std::sync::Arc;
 use workflow_core::abortable::Abortable;
 
 pub async fn deposit_with_payload(


### PR DESCRIPTION
## Summary
- Remove unused imports from `libs/kaspa/lib/core/src/balance.rs`
- Prefix unused parameter with underscore in `client.rs` (`_domain_kas`)
- Remove `#![allow(unused)]` from `ops/user/deposit.rs` and clean up all unused imports

## Test plan
- [x] `cargo build --package dymension-kaspa --package core` compiles with no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)