### PR TITLE
fix(sealevel): fail-fast with clear error for missing signer key

### DIFF
--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -355,7 +355,14 @@ impl ChainConf {
                     .map_err(Into::into)
             }
             ChainConnectionConf::Sealevel(conf) => {
-                let keypair = self.sealevel_signer().await.context(ctx)?;
+                let keypair = self.sealevel_signer().await.context(ctx)?.ok_or_else(|| {
+                    eyre!(
+                        "Sealevel chain '{}' requires a signer key for mailbox operations. \
+                         Please configure --chains.{}.signer.key or --defaultSigner.key",
+                        self.domain.name(),
+                        self.domain.name()
+                    )
+                })?;
 
                 let provider =
                     Arc::new(build_sealevel_provider(self, &locator, &[], conf, metrics));
@@ -367,7 +374,7 @@ impl ChainConf {
                     tx_submitter,
                     conf,
                     &locator,
-                    keypair.map(h_sealevel::SealevelKeypair::new),
+                    Some(h_sealevel::SealevelKeypair::new(keypair)),
                 )
                 .map(|m| Box::new(m) as Box<dyn Mailbox>)
                 .map_err(Into::into)
@@ -934,13 +941,20 @@ impl ChainConf {
             }
             ChainConnectionConf::Fuel(_) => todo!(),
             ChainConnectionConf::Sealevel(conf) => {
-                let keypair = self.sealevel_signer().await.context(ctx)?;
+                let keypair = self.sealevel_signer().await.context(ctx)?.ok_or_else(|| {
+                    eyre!(
+                        "Sealevel chain '{}' requires a signer key for ISM operations. \
+                         Please configure --chains.{}.signer.key or --defaultSigner.key",
+                        self.domain.name(),
+                        self.domain.name()
+                    )
+                })?;
                 let provider =
                     Arc::new(build_sealevel_provider(self, &locator, &[], conf, metrics));
                 let ism = Box::new(h_sealevel::SealevelInterchainSecurityModule::new(
                     provider,
                     locator,
-                    keypair.map(h_sealevel::SealevelKeypair::new),
+                    Some(h_sealevel::SealevelKeypair::new(keypair)),
                 ));
                 Ok(ism as Box<dyn InterchainSecurityModule>)
             }
@@ -995,13 +1009,20 @@ impl ChainConf {
 
             ChainConnectionConf::Fuel(_) => todo!(),
             ChainConnectionConf::Sealevel(conf) => {
-                let keypair = self.sealevel_signer().await.context(ctx)?;
+                let keypair = self.sealevel_signer().await.context(ctx)?.ok_or_else(|| {
+                    eyre!(
+                        "Sealevel chain '{}' requires a signer key for multisig ISM operations. \
+                         Please configure --chains.{}.signer.key or --defaultSigner.key",
+                        self.domain.name(),
+                        self.domain.name()
+                    )
+                })?;
                 let provider =
                     Arc::new(build_sealevel_provider(self, &locator, &[], conf, metrics));
                 let ism = Box::new(h_sealevel::SealevelMultisigIsm::new(
                     provider,
                     locator,
-                    keypair.map(h_sealevel::SealevelKeypair::new),
+                    Some(h_sealevel::SealevelKeypair::new(keypair)),
                 ));
                 Ok(ism as Box<dyn MultisigIsm>)
             }


### PR DESCRIPTION
## Summary

- Add early validation for Sealevel signer key in `build_mailbox()`, `build_ism()`, and `build_multisig_ism()`
- Provide clear, actionable error message when signer key is missing
- Fixes confusing "No return data from InboxGetRecipientIsm instruction" error

## Problem

When a signer key is missing for Sealevel chains (e.g., missing `--chains.solanatestnet.signer.key` flag), the relayer would fail deep in the execution path with a confusing error message:

```
ERROR hyperlane_sealevel::mailbox: error: No return data from InboxGetRecipientIsm instruction
    at chains/hyperlane-sealevel/src/mailbox.rs:447
```

This error gives no indication that the actual problem is a missing signer key.

## Solution

Add early validation to require a signer for Sealevel chains, failing immediately at startup with a clear error message:

```
Error: Sealevel chain 'solanatestnet' requires a signer key for mailbox operations.
Please configure --chains.solanatestnet.signer.key or --defaultSigner.key
```

## Related

- Upstream issue: https://github.com/hyperlane-xyz/hyperlane-monorepo/issues/7582

## Test plan

- [ ] Run relayer without signer key for Sealevel chain → should fail immediately with clear error
- [ ] Run relayer with signer key → should work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)