### PR TITLE
fix(relayer): improve merkle tree sync error logging

### DIFF
--- a/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
+++ b/rust/main/agents/relayer/src/msg/metadata/multisig/base.rs
@@ -251,15 +251,10 @@ async fn metadata_build<T: MultisigIsmMetadataBuilder>(
     let metadata = ism_builder
         .fetch_metadata(&validators, threshold, message, &checkpoint_syncer)
         .await
-        .map_err(|err| MetadataBuildError::FailedToBuild(format!("fetch_metadata error: {}", err)))?
+        .map_err(|err| MetadataBuildError::FailedToBuild(format!("fetch_metadata: {}", err)))?
         .ok_or_else(|| {
-            let error_msg =
-                "Unable to reach quorum (no validators returned valid checkpoints in range)";
-            info!(
-                hyp_message=?message, ?validators, threshold, ism=%multisig_ism.address(),
-                "Could not fetch metadata: {}", error_msg
-            );
-            MetadataBuildError::FailedToBuild(error_msg.to_string())
+            // Detailed error already logged by fetch_metadata
+            MetadataBuildError::CouldNotFetch
         })?;
 
     debug!(hyp_message=?message, ?metadata.checkpoint, "Found checkpoint with quorum");


### PR DESCRIPTION
## Summary
Add definitive error messages when relayer cannot build metadata due to merkle tree not being synced. The key improvement is comparing message nonce against the local tree's highest synced index:

- `"Merkle tree not synced: tree is empty. Message nonce is X, need to sync to at least that index"`
- `"Merkle tree not synced: tree synced to index Y, but message nonce is X. Need Z more"`

This replaces vague "leaf not found" or "unable to reach quorum" errors with actionable information that tells you exactly how far behind the tree sync is.

## Test plan
- [ ] Run relayer with unreachable origin RPC and verify error messages are clear
- [ ] Verify cargo check passes
- [ ] Verify cargo fmt passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)