### PR TITLE
fix(cosmos): skip IGP denom validation in relayer

### DIFF
--- a/rust/main/chains/hyperlane-cosmos/src/native/indexers/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-cosmos/src/native/indexers/interchain_gas.rs
@@ -44,23 +44,12 @@ impl CosmosNativeInterchainGas {
         })
     }
 
-    /// parses a cosmos sdk.Coin in a string representation '{amoun}{denom}'
-    /// only returns the amount if it matches the native token in the config
+    /// Parses a cosmos sdk.Coin in string representation '{amount}{denom}'.
+    /// Extracts the amount, trusting the IGP contract to validate the denom.
     fn parse_gas_payment(&self, coin: &str) -> ChainResult<U256> {
-        // Convert the coin to a u256 by taking everything before the first non-numeric character
+        let _ = &self.native_token; // Field kept for API compatibility
         match coin.find(|c: char| !c.is_numeric()) {
-            Some(first_non_numeric) => {
-                let amount = U256::from_dec_str(&coin[..first_non_numeric])?;
-                let denom = &coin[first_non_numeric..];
-                if denom == self.native_token {
-                    Ok(amount)
-                } else {
-                    Err(ChainCommunicationError::from_other_str(&format!(
-                        "invalid gas payment: {coin} expected denom: {}",
-                        self.native_token
-                    )))
-                }
-            }
+            Some(first_non_numeric) => Ok(U256::from_dec_str(&coin[..first_non_numeric])?),
             None => Err(ChainCommunicationError::from_other_str(&format!(
                 "invalid coin: {coin}"
             ))),


### PR DESCRIPTION
## Summary

Remove denom validation from Cosmos native IGP indexer - trust the IGP contract.

## Problem

The relayer was rejecting gas payments in non-native tokens (e.g., `hyperlane/0x726f757465725f617070...`) because it validated that payments must be in `adym`.

However, the IGP contract already validates payments before emitting events. If the relayer trusts the IGP contract address (configured explicitly), it should trust any payment event from that contract.

## Solution

Remove the denom check in `parse_gas_payment()` while preserving struct/API for minimal fork drift.

**Diff: 1 file, +4/-15 lines**

## Test plan

- [x] Build passes: `cargo check -p hyperlane-cosmos`
- [ ] Deploy to relayer and verify gas payments in non-native tokens are indexed

🤖 Generated with [Claude Code](https://claude.com/claude-code)