### PR TITLE
chore(infra): add dymension mainnet safe addresses

### DIFF
--- a/typescript/infra/config/environments/mainnet3/governance/safe/dymension.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/safe/dymension.ts
@@ -2,5 +2,7 @@ import { ChainMap } from '@hyperlane-xyz/sdk';
 import { Address } from '@hyperlane-xyz/utils';
 
 export const dymensionSafes: ChainMap<Address> = {
-  sepolia: 'TODO: populate',
+  ethereum: '0x97E4720cE86428FC2609eA0B36a69F5fB68a6712',
+  base: '0x97E4720cE86428FC2609eA0B36a69F5fB68a6712',
+  bsc: '0x97E4720cE86428FC2609eA0B36a69F5fB68a6712',
 };

--- a/typescript/infra/config/environments/mainnet3/governance/signers/dymension.ts
+++ b/typescript/infra/config/environments/mainnet3/governance/signers/dymension.ts
@@ -1,7 +1,9 @@
 import { Address } from '@hyperlane-xyz/utils';
 
 export const dymensionSigners: Address[] = [
-  // TODO: populate
+  '0x7DF3E48032AEadBf9125e0396bE50e7cDF29D2FB',
+  '0x5C6733E5B9FC1e943f6Ffad86f6B2D2A8982f7E4',
+  '0xaBc2D203ea7743cd11CE7d2111Bc7d109d5664e1',
 ];
 
 export const dymensionThreshold = 2;


### PR DESCRIPTION
## Summary
- Register Dymension's 2-of-3 Safe multisig for ethereum, base, and bsc mainnets
- Same Safe address deployed across all three chains via create2
- Add the 3 signer addresses to the signers config

**Safe:** `0x97E4720cE86428FC2609eA0B36a69F5fB68a6712`
**Threshold:** 2 of 3
**Chains:** ethereum, base, bsc

## Test plan
- [ ] Verify safe addresses resolve correctly via infra tooling
- [ ] Test `check-safe-signers` script against the new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)