### PR TITLE
feat(kaspa-tools): add decode-payload command

### DIFF
--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -57,6 +57,12 @@ async fn run(cli: Cli) {
             let sim = TrafficSim::new(sim).await.unwrap();
             sim.run().await.unwrap();
         }
+        Commands::DecodePayload(args) => {
+            if let Err(e) = x::decode_payload::decode_payload(&args.payload) {
+                eprintln!("decode payload: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 }
 

--- a/rust/main/utils/kaspa-tools/src/x/args.rs
+++ b/rust/main/utils/kaspa-tools/src/x/args.rs
@@ -36,6 +36,9 @@ pub enum Commands {
     /// Simulate traffic
     #[clap(name = "sim")]
     SimulateTraffic(SimulateTrafficCli),
+    /// Decode a Kaspa withdrawal tx payload to extract Hyperlane message IDs
+    #[clap(name = "decode-payload")]
+    DecodePayload(DecodePayloadCli),
 }
 
 #[derive(Subcommand, Debug)]
@@ -249,4 +252,12 @@ impl DepositCli {
             wallet_dir: self.wallet.wallet_dir.clone(),
         }
     }
+}
+
+#[derive(Args, Debug)]
+pub struct DecodePayloadCli {
+    /// The payload to decode (hex string, with or without 0x prefix).
+    /// This is the payload field from a Kaspa withdrawal transaction.
+    #[arg(required = true, index = 1)]
+    pub payload: String,
 }

--- a/rust/main/utils/kaspa-tools/src/x/decode_payload.rs
+++ b/rust/main/utils/kaspa-tools/src/x/decode_payload.rs
@@ -1,0 +1,70 @@
+use dymension_kaspa::ops::payload::MessageIDs;
+
+/// Decode a Kaspa withdrawal transaction payload (hex string) to extract Hyperlane message IDs.
+/// The payload is protobuf-encoded MessageIDs containing a list of 32-byte message IDs.
+pub fn decode_payload(payload: &str) -> Result<(), eyre::Error> {
+    // Strip optional 0x prefix
+    let payload = payload.strip_prefix("0x").unwrap_or(payload);
+
+    let message_ids = MessageIDs::from_tx_payload(payload)?;
+
+    if message_ids.0.is_empty() {
+        println!("No message IDs found in payload");
+        return Ok(());
+    }
+
+    println!("Decoded {} Hyperlane message ID(s):", message_ids.0.len());
+    for (i, id) in message_ids.0.iter().enumerate() {
+        println!("  [{}] 0x{}", i, hex::encode(id.0.as_bytes()));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dymension_kaspa::ops::payload::MessageID;
+    use hyperlane_core::H256;
+
+    #[test]
+    fn test_decode_known_payload() {
+        // Create a known payload by encoding some message IDs
+        let msg_id1 = MessageID(H256::from([1u8; 32]));
+        let msg_id2 = MessageID(H256::from([2u8; 32]));
+        let message_ids = MessageIDs::new(vec![msg_id1, msg_id2]);
+
+        let encoded = hex::encode(message_ids.to_bytes());
+
+        // Decode should succeed
+        let result = decode_payload(&encoded);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decode_with_0x_prefix() {
+        let msg_id = MessageID(H256::from([42u8; 32]));
+        let message_ids = MessageIDs::new(vec![msg_id]);
+
+        let encoded = format!("0x{}", hex::encode(message_ids.to_bytes()));
+
+        let result = decode_payload(&encoded);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_decode_invalid_payload() {
+        let result = decode_payload("invalid_hex");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_decode_empty_payload() {
+        // Empty protobuf message
+        let message_ids = MessageIDs::new(vec![]);
+        let encoded = hex::encode(message_ids.to_bytes());
+
+        let result = decode_payload(&encoded);
+        assert!(result.is_ok());
+    }
+}

--- a/rust/main/utils/kaspa-tools/src/x/mod.rs
+++ b/rust/main/utils/kaspa-tools/src/x/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod decode_payload;
 pub mod deposit;
 pub mod escrow;
 pub mod relayer;


### PR DESCRIPTION
## Summary
- Add `decode-payload` command to kaspa-tools CLI
- Decodes Kaspa withdrawal tx payloads to extract Hyperlane message IDs
- Useful for debugging/viewing which messages are contained in a Kaspa transaction

## Usage
```bash
kaspa-tools decode-payload <PAYLOAD>

# Example:
kaspa-tools decode-payload 0a204df5d067aa7f5260d3dd57dc99ddcf2fe70e34c396273e1d8fe53a840a5ac00e
# Output:
# Decoded 1 Hyperlane message ID(s):
#   [0] 0x4df5d067aa7f5260d3dd57dc99ddcf2fe70e34c396273e1d8fe53a840a5ac00e
```

## Test plan
- [x] Build passes (`cargo build --package kaspa-tools`)
- [x] Unit tests pass (`cargo test --package kaspa-tools -- decode_payload`)
- [x] Tested with real withdrawal payloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)