### PR TITLE
feat(kaspa-tools): add DRY roundtrip command

### DIFF
--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -57,20 +57,14 @@ async fn run(cli: Cli) {
             let sim = TrafficSim::new(sim).await.unwrap();
             sim.run().await.unwrap();
         }
-        Commands::Roundtrip(args) => {
-            let result = sim::roundtrip::do_roundtrip(args).await;
-            match result {
-                Ok(r) => {
-                    if !r.is_success() {
-                        std::process::exit(1);
-                    }
-                }
-                Err(e) => {
-                    eprintln!("roundtrip failed: {}", e);
-                    std::process::exit(1);
-                }
+        Commands::Roundtrip(args) => match sim::roundtrip::do_roundtrip(args).await {
+            Ok(true) => {}
+            Ok(false) => std::process::exit(1),
+            Err(e) => {
+                eprintln!("error: {}", e);
+                std::process::exit(1);
             }
-        }
+        },
         Commands::DecodePayload(args) => {
             if let Err(e) = x::decode_payload::decode_payload(&args.payload) {
                 eprintln!("decode payload: {e}");

--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use x::args::{Cli, Commands, ValidatorAction, ValidatorBackend};
+use x::args::{Cli, Commands, SimAction, ValidatorAction, ValidatorBackend};
 
 mod sim;
 use sim::{SimulateTrafficArgs, TrafficSim};
@@ -52,11 +52,27 @@ async fn run(cli: Cli) {
             println!("Relayer address: {}", signer.address);
             println!("Relayer private key: {}", signer.private_key);
         }
-        Commands::SimulateTraffic(args) => {
-            let sim = SimulateTrafficArgs::try_from(args).unwrap();
-            let sim = TrafficSim::new(sim).await.unwrap();
-            sim.run().await.unwrap();
-        }
+        Commands::Sim { action } => match action {
+            SimAction::Stresstest(args) => {
+                let sim = SimulateTrafficArgs::try_from(args).unwrap();
+                let sim = TrafficSim::new(sim).await.unwrap();
+                sim.run().await.unwrap();
+            }
+            SimAction::Roundtrip(args) => {
+                let result = sim::roundtrip::do_roundtrip(args).await;
+                match result {
+                    Ok(r) => {
+                        if !r.is_success() {
+                            std::process::exit(1);
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("roundtrip failed: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
+        },
     }
 }
 

--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -1,9 +1,15 @@
 use clap::Parser;
-use x::args::{Cli, Commands, ValidatorAction, ValidatorBackend};
+use x::args::{Cli, Commands, SimulateTrafficCli, ValidatorAction, ValidatorBackend};
 
 mod sim;
 use sim::{SimulateTrafficArgs, TrafficSim};
 mod x;
+
+async fn run_sim(args: SimulateTrafficCli) -> eyre::Result<()> {
+    let sim = SimulateTrafficArgs::try_from(args)?;
+    let sim = TrafficSim::new(sim).await?;
+    sim.run().await
+}
 
 async fn run(cli: Cli) {
     tracing_subscriber::fmt::init();
@@ -53,18 +59,17 @@ async fn run(cli: Cli) {
             println!("Relayer private key: {}", signer.private_key);
         }
         Commands::Sim(args) => {
-            let sim = SimulateTrafficArgs::try_from(args).unwrap();
-            let sim = TrafficSim::new(sim).await.unwrap();
-            sim.run().await.unwrap();
-        }
-        Commands::Roundtrip(args) => match sim::roundtrip::do_roundtrip(args).await {
-            Ok(true) => {}
-            Ok(false) => std::process::exit(1),
-            Err(e) => {
-                eprintln!("error: {}", e);
+            if let Err(e) = run_sim(args).await {
+                eprintln!("error: {e}");
                 std::process::exit(1);
             }
-        },
+        }
+        Commands::Roundtrip(args) => {
+            if let Err(e) = sim::roundtrip::do_roundtrip(args).await {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        }
         Commands::DecodePayload(args) => {
             if let Err(e) = x::decode_payload::decode_payload(&args.payload) {
                 eprintln!("decode payload: {e}");

--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use x::args::{Cli, Commands, SimAction, ValidatorAction, ValidatorBackend};
+use x::args::{Cli, Commands, ValidatorAction, ValidatorBackend};
 
 mod sim;
 use sim::{SimulateTrafficArgs, TrafficSim};
@@ -52,27 +52,25 @@ async fn run(cli: Cli) {
             println!("Relayer address: {}", signer.address);
             println!("Relayer private key: {}", signer.private_key);
         }
-        Commands::Sim { action } => match action {
-            SimAction::Stresstest(args) => {
-                let sim = SimulateTrafficArgs::try_from(args).unwrap();
-                let sim = TrafficSim::new(sim).await.unwrap();
-                sim.run().await.unwrap();
-            }
-            SimAction::Roundtrip(args) => {
-                let result = sim::roundtrip::do_roundtrip(args).await;
-                match result {
-                    Ok(r) => {
-                        if !r.is_success() {
-                            std::process::exit(1);
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("roundtrip failed: {}", e);
+        Commands::Sim(args) => {
+            let sim = SimulateTrafficArgs::try_from(args).unwrap();
+            let sim = TrafficSim::new(sim).await.unwrap();
+            sim.run().await.unwrap();
+        }
+        Commands::Roundtrip(args) => {
+            let result = sim::roundtrip::do_roundtrip(args).await;
+            match result {
+                Ok(r) => {
+                    if !r.is_success() {
                         std::process::exit(1);
                     }
                 }
+                Err(e) => {
+                    eprintln!("roundtrip failed: {}", e);
+                    std::process::exit(1);
+                }
             }
-        },
+        }
         Commands::DecodePayload(args) => {
             if let Err(e) = x::decode_payload::decode_payload(&args.payload) {
                 eprintln!("decode payload: {e}");

--- a/rust/main/utils/kaspa-tools/src/sim/kaspa_whale_pool.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/kaspa_whale_pool.rs
@@ -10,7 +10,7 @@ use tracing::info;
 pub struct KaspaWhale {
     pub wallet: EasyKaspaWallet,
     pub secret: Secret,
-    last_used: Mutex<Instant>,
+    pub last_used: Mutex<Instant>,
     pub id: usize,
 }
 

--- a/rust/main/utils/kaspa-tools/src/sim/mod.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/mod.rs
@@ -1,9 +1,10 @@
-mod hub_whale_pool;
-mod kaspa_whale_pool;
-mod key_cosmos;
+pub mod hub_whale_pool;
+pub mod kaspa_whale_pool;
+pub mod key_cosmos;
 mod key_kaspa;
-mod round_trip;
+pub mod round_trip;
+pub mod roundtrip;
 mod sim;
-mod stats;
-mod util;
+pub mod stats;
+pub mod util;
 pub use sim::*;

--- a/rust/main/utils/kaspa-tools/src/sim/mod.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/mod.rs
@@ -1,10 +1,10 @@
-pub mod hub_whale_pool;
-pub mod kaspa_whale_pool;
-pub mod key_cosmos;
+mod hub_whale_pool;
+mod kaspa_whale_pool;
+mod key_cosmos;
 mod key_kaspa;
-pub mod round_trip;
+mod round_trip;
 pub mod roundtrip;
 mod sim;
-pub mod stats;
-pub mod util;
+mod stats;
+mod util;
 pub use sim::*;

--- a/rust/main/utils/kaspa-tools/src/sim/round_trip.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/round_trip.rs
@@ -3,6 +3,7 @@ use super::kaspa_whale_pool::KaspaWhale;
 use super::key_cosmos::EasyHubKey;
 use super::key_kaspa::get_kaspa_keypair;
 use super::stats::RoundTripStats;
+use super::util::now_millis;
 use cometbft_rpc::endpoint::broadcast::tx_commit::Response as HubResponse;
 use cosmos_sdk_proto::cosmos::bank::v1beta1::MsgSend;
 use cosmos_sdk_proto::cosmos::base::v1beta1::Coin;
@@ -31,13 +32,6 @@ use tracing::warn;
 const MAX_RETRIES: usize = 3;
 const RETRY_DELAY_MS: u64 = 2000;
 const HUB_FUND_AMOUNT: u64 = 50_000_000_000_000_000; // 0.05 dym to pay gas
-
-fn now_millis() -> u128 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_millis()
-}
 
 fn is_retryable(error: &eyre::Error) -> bool {
     let err_str = error.to_string().to_lowercase();

--- a/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio_util::sync::CancellationToken;
 
-pub async fn do_roundtrip(cli: RoundtripCli) -> Result<bool> {
+pub async fn do_roundtrip(cli: RoundtripCli) -> Result<()> {
     let kaspa_network = cli.bridge.parse_kaspa_network()?;
     let escrow_address = cli.bridge.parse_escrow_address()?;
 
@@ -123,13 +123,11 @@ pub async fn do_roundtrip(cli: RoundtripCli) -> Result<bool> {
 
     // Print result
     println!();
-    match final_stats {
-        Some(stats) => print_result(&stats),
-        None => {
-            println!("FAILED: no response");
-            Ok(false)
-        }
-    }
+    let Some(stats) = final_stats else {
+        println!("FAILED: no response");
+        return Err(eyre::eyre!("no stats received"));
+    };
+    print_result(&stats)
 }
 
 fn print_stage(stage: &str) {
@@ -145,7 +143,7 @@ fn print_stage(stage: &str) {
     println!("{}", msg);
 }
 
-fn print_result(stats: &RoundTripStats) -> Result<bool> {
+fn print_result(stats: &RoundTripStats) -> Result<()> {
     let deposit_ok = stats.deposit_error.is_none() && stats.deposit_credit_error.is_none();
     let withdraw_ok = stats.withdrawal_error.is_none() && stats.withdraw_credit_error.is_none();
 
@@ -185,7 +183,11 @@ fn print_result(stats: &RoundTripStats) -> Result<bool> {
         println!("INCOMPLETE");
     }
 
-    Ok(deposit_ok && withdraw_ok && stats.stage == "Complete")
+    if deposit_ok && withdraw_ok && stats.stage == "Complete" {
+        Ok(())
+    } else {
+        Err(eyre::eyre!("roundtrip failed"))
+    }
 }
 
 fn format_duration(ms: u128) -> String {

--- a/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
@@ -1,0 +1,249 @@
+//! Single roundtrip command - reuses round_trip.rs logic for a single test run
+//! Deposits from kaspa wallet to hub, then withdraws back to the same kaspa address
+
+use super::hub_whale_pool::HubWhale;
+use super::kaspa_whale_pool::KaspaWhale;
+use super::key_cosmos::EasyHubKey;
+use super::round_trip::{do_round_trip, TaskArgs, TaskResources};
+use super::stats::RoundTripStats;
+use super::util::{create_cosmos_provider, SOMPI_PER_KAS};
+use crate::x::args::RoundtripCli;
+use dym_kas_core::api::base::RateLimitConfig;
+use dym_kas_core::api::client::HttpClient;
+use dym_kas_core::wallet::{EasyKaspaWallet, EasyKaspaWalletArgs};
+use eyre::Result;
+use kaspa_wallet_core::prelude::Secret;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+use tokio::sync::Mutex as AsyncMutex;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+pub async fn do_roundtrip(cli: RoundtripCli) -> Result<RoundtripResult> {
+    info!("starting roundtrip test");
+
+    let kaspa_network = cli.bridge.parse_kaspa_network()?;
+    let escrow_address = cli.bridge.parse_escrow_address()?;
+
+    // Initialize Kaspa wallet
+    info!("initializing kaspa wallet");
+    let kaspa_wallet = EasyKaspaWallet::try_new(EasyKaspaWalletArgs {
+        wallet_secret: cli.kaspa_wallet_secret.clone(),
+        wrpc_url: cli.bridge.kaspa_wrpc_url.clone(),
+        net: kaspa_network.clone(),
+        storage_folder: cli.kaspa_wallet_dir.clone(),
+    })
+    .await?;
+
+    let kaspa_secret = Secret::from(cli.kaspa_wallet_secret.clone());
+    let kaspa_receive_addr = kaspa_wallet.wallet.account()?.receive_address()?;
+
+    // Initialize Hub wallet
+    let hub_key = EasyHubKey::from_hex(&cli.hub_priv_key);
+    let hub_address = hub_key.signer().address_string.clone();
+
+    // Print configuration
+    println!("=== Kaspa Bridge Roundtrip Test ===");
+    println!();
+    println!("Configuration:");
+    println!("  Kaspa wallet:  {}", kaspa_receive_addr);
+    println!("  Hub wallet:    {}", hub_address);
+    println!("  Escrow:        {}", escrow_address);
+    println!(
+        "  Deposit:       {} sompi ({:.2} KAS)",
+        cli.bridge.deposit_amount,
+        cli.bridge.deposit_amount as f64 / SOMPI_PER_KAS as f64
+    );
+    println!("  Network:       {}", cli.bridge.kaspa_network);
+    println!("  Timeout:       {}s", cli.timeout);
+    println!();
+
+    // Create Hub provider
+    let hub_provider = create_cosmos_provider(
+        &hub_key,
+        &cli.bridge.hub_rpc_url,
+        &cli.bridge.hub_grpc_url,
+        &cli.bridge.hub_chain_id,
+        &cli.bridge.hub_prefix,
+        &cli.bridge.hub_denom,
+        cli.bridge.hub_decimals,
+    )
+    .await?;
+
+    // Create REST client for Kaspa
+    let kas_rest = HttpClient::new(
+        cli.bridge.kaspa_rest_url.clone(),
+        RateLimitConfig::default(),
+    );
+
+    // Build TaskArgs (reusing existing struct from round_trip.rs)
+    let task_args = TaskArgs {
+        domain_kas: cli.bridge.domain_kas,
+        token_kas_placeholder: cli.bridge.token_kas_placeholder,
+        domain_hub: cli.bridge.domain_hub,
+        token_hub: cli.bridge.token_hub,
+        escrow_address,
+        deposit_amount: cli.bridge.deposit_amount,
+        withdrawal_fee_pct: cli.bridge.withdrawal_fee_pct,
+    };
+
+    let task_resources = TaskResources {
+        hub: hub_provider.clone(),
+        args: task_args,
+        kas_rest,
+        kaspa_network,
+    };
+
+    // Create single-use "whale" wrappers to satisfy the round_trip interface
+    let kaspa_whale = Arc::new(KaspaWhale {
+        wallet: kaspa_wallet,
+        secret: kaspa_secret,
+        last_used: Mutex::new(Instant::now()),
+        id: 0,
+    });
+
+    let hub_whale = Arc::new(HubWhale {
+        provider: hub_provider,
+        last_used: Mutex::new(Instant::now()),
+        id: 0,
+        tx_lock: AsyncMutex::new(()),
+    });
+
+    // Create a channel to receive stats updates
+    let (tx, mut rx) = mpsc::channel::<RoundTripStats>(32);
+
+    // Create cancellation token with timeout
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+
+    // Spawn timeout task
+    let timeout_secs = cli.timeout;
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(timeout_secs)).await;
+        cancel_clone.cancel();
+    });
+
+    // Run the roundtrip using existing logic
+    println!("[1/2] Deposit: KAS -> Hub");
+
+    do_round_trip(task_resources, kaspa_whale, hub_whale, &tx, 0, cancel_token).await;
+
+    // Drain stats channel to get final result
+    drop(tx);
+    let mut final_stats: Option<RoundTripStats> = None;
+    while let Some(stats) = rx.recv().await {
+        final_stats = Some(stats);
+    }
+
+    let result = match final_stats {
+        Some(stats) => RoundtripResult::from_stats(stats),
+        None => RoundtripResult::error("no stats received from roundtrip"),
+    };
+
+    result.print_summary();
+    Ok(result)
+}
+
+/// Result of a roundtrip test
+#[derive(Debug)]
+pub struct RoundtripResult {
+    pub deposit_tx_id: Option<String>,
+    pub deposit_latency_ms: Option<u128>,
+    pub deposit_error: Option<String>,
+    pub withdrawal_tx_id: Option<String>,
+    pub withdrawal_latency_ms: Option<u128>,
+    pub withdrawal_error: Option<String>,
+}
+
+impl RoundtripResult {
+    fn from_stats(stats: RoundTripStats) -> Self {
+        let deposit_latency_ms = stats
+            .deposit_credit_time_millis
+            .and_then(|credit| stats.kaspa_deposit_tx_time_millis.map(|tx| credit - tx));
+
+        let withdrawal_latency_ms = stats
+            .withdraw_credit_time_millis
+            .and_then(|credit| stats.hub_withdraw_tx_time_millis.map(|tx| credit - tx));
+
+        Self {
+            deposit_tx_id: stats.kaspa_deposit_tx_id.map(|id| id.to_string()),
+            deposit_latency_ms,
+            deposit_error: stats.deposit_error.or(stats.deposit_credit_error),
+            withdrawal_tx_id: stats.hub_withdraw_tx_id,
+            withdrawal_latency_ms,
+            withdrawal_error: stats.withdrawal_error.or(stats.withdraw_credit_error),
+        }
+    }
+
+    fn error(msg: &str) -> Self {
+        Self {
+            deposit_tx_id: None,
+            deposit_latency_ms: None,
+            deposit_error: Some(msg.to_string()),
+            withdrawal_tx_id: None,
+            withdrawal_latency_ms: None,
+            withdrawal_error: None,
+        }
+    }
+
+    fn format_duration(ms: u128) -> String {
+        let total_secs = ms / 1000;
+        let mins = total_secs / 60;
+        let secs = total_secs % 60;
+        if mins > 0 {
+            format!("{}min {}sec", mins, secs)
+        } else {
+            format!("{}sec", secs)
+        }
+    }
+
+    pub fn print_summary(&self) {
+        let deposit_status = if let Some(ref err) = self.deposit_error {
+            format!("FAILED ({})", err)
+        } else if let Some(latency) = self.deposit_latency_ms {
+            format!("OK {}", Self::format_duration(latency))
+        } else {
+            "INCOMPLETE".to_string()
+        };
+
+        let withdrawal_status = if let Some(ref err) = self.withdrawal_error {
+            format!("FAILED ({})", err)
+        } else if let Some(latency) = self.withdrawal_latency_ms {
+            format!("OK {}", Self::format_duration(latency))
+        } else if self.deposit_error.is_some() {
+            "SKIPPED (deposit failed)".to_string()
+        } else {
+            "INCOMPLETE".to_string()
+        };
+
+        let deposit_tx_suffix = self
+            .deposit_tx_id
+            .as_ref()
+            .map(|tx| format!(" (tx: {})", tx))
+            .unwrap_or_default();
+        let withdrawal_tx_suffix = self
+            .withdrawal_tx_id
+            .as_ref()
+            .map(|tx| format!(" (tx: {})", tx))
+            .unwrap_or_default();
+
+        println!();
+        println!("=== Summary ===");
+        println!(
+            "Deposit:    KAS -> Hub  {}{}",
+            deposit_status, deposit_tx_suffix
+        );
+        println!(
+            "Withdrawal: Hub -> KAS  {}{}",
+            withdrawal_status, withdrawal_tx_suffix
+        );
+    }
+
+    pub fn is_success(&self) -> bool {
+        self.deposit_error.is_none()
+            && self.withdrawal_error.is_none()
+            && self.deposit_latency_ms.is_some()
+            && self.withdrawal_latency_ms.is_some()
+    }
+}

--- a/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
@@ -1,5 +1,4 @@
-//! Single roundtrip command - reuses round_trip.rs logic for a single test run
-//! Deposits from kaspa wallet to hub, then withdraws back to the same kaspa address
+//! Single roundtrip command - deposit from Kaspa to Hub, then withdraw back
 
 use super::hub_whale_pool::HubWhale;
 use super::kaspa_whale_pool::KaspaWhale;
@@ -18,16 +17,12 @@ use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
 
-pub async fn do_roundtrip(cli: RoundtripCli) -> Result<RoundtripResult> {
-    info!("starting roundtrip test");
-
+pub async fn do_roundtrip(cli: RoundtripCli) -> Result<bool> {
     let kaspa_network = cli.bridge.parse_kaspa_network()?;
     let escrow_address = cli.bridge.parse_escrow_address()?;
 
-    // Initialize Kaspa wallet
-    info!("initializing kaspa wallet");
+    // Initialize wallets
     let kaspa_wallet = EasyKaspaWallet::try_new(EasyKaspaWalletArgs {
         wallet_secret: cli.kaspa_wallet_secret.clone(),
         wrpc_url: cli.bridge.kaspa_wrpc_url.clone(),
@@ -35,31 +30,12 @@ pub async fn do_roundtrip(cli: RoundtripCli) -> Result<RoundtripResult> {
         storage_folder: cli.kaspa_wallet_dir.clone(),
     })
     .await?;
-
     let kaspa_secret = Secret::from(cli.kaspa_wallet_secret.clone());
-    let kaspa_receive_addr = kaspa_wallet.wallet.account()?.receive_address()?;
+    let kaspa_addr = kaspa_wallet.wallet.account()?.receive_address()?;
 
-    // Initialize Hub wallet
     let hub_key = EasyHubKey::from_hex(&cli.hub_priv_key);
-    let hub_address = hub_key.signer().address_string.clone();
+    let hub_addr = hub_key.signer().address_string.clone();
 
-    // Print configuration
-    println!("=== Kaspa Bridge Roundtrip Test ===");
-    println!();
-    println!("Configuration:");
-    println!("  Kaspa wallet:  {}", kaspa_receive_addr);
-    println!("  Hub wallet:    {}", hub_address);
-    println!("  Escrow:        {}", escrow_address);
-    println!(
-        "  Deposit:       {} sompi ({:.2} KAS)",
-        cli.bridge.deposit_amount,
-        cli.bridge.deposit_amount as f64 / SOMPI_PER_KAS as f64
-    );
-    println!("  Network:       {}", cli.bridge.kaspa_network);
-    println!("  Timeout:       {}s", cli.timeout);
-    println!();
-
-    // Create Hub provider
     let hub_provider = create_cosmos_provider(
         &hub_key,
         &cli.bridge.hub_rpc_url,
@@ -71,13 +47,17 @@ pub async fn do_roundtrip(cli: RoundtripCli) -> Result<RoundtripResult> {
     )
     .await?;
 
-    // Create REST client for Kaspa
-    let kas_rest = HttpClient::new(
-        cli.bridge.kaspa_rest_url.clone(),
-        RateLimitConfig::default(),
+    // Print config
+    println!(
+        "Roundtrip: {} sompi ({:.2} KAS)",
+        cli.bridge.deposit_amount,
+        cli.bridge.deposit_amount as f64 / SOMPI_PER_KAS as f64
     );
+    println!("  Kaspa: {}", kaspa_addr);
+    println!("  Hub:   {}", hub_addr);
+    println!();
 
-    // Build TaskArgs (reusing existing struct from round_trip.rs)
+    // Build resources
     let task_args = TaskArgs {
         domain_kas: cli.bridge.domain_kas,
         token_kas_placeholder: cli.bridge.token_kas_placeholder,
@@ -91,18 +71,20 @@ pub async fn do_roundtrip(cli: RoundtripCli) -> Result<RoundtripResult> {
     let task_resources = TaskResources {
         hub: hub_provider.clone(),
         args: task_args,
-        kas_rest,
+        kas_rest: HttpClient::new(
+            cli.bridge.kaspa_rest_url.clone(),
+            RateLimitConfig::default(),
+        ),
         kaspa_network,
     };
 
-    // Create single-use "whale" wrappers to satisfy the round_trip interface
+    // Wrap as whales (required by do_round_trip interface)
     let kaspa_whale = Arc::new(KaspaWhale {
         wallet: kaspa_wallet,
         secret: kaspa_secret,
         last_used: Mutex::new(Instant::now()),
         id: 0,
     });
-
     let hub_whale = Arc::new(HubWhale {
         provider: hub_provider,
         last_used: Mutex::new(Instant::now()),
@@ -110,140 +92,107 @@ pub async fn do_roundtrip(cli: RoundtripCli) -> Result<RoundtripResult> {
         tx_lock: AsyncMutex::new(()),
     });
 
-    // Create a channel to receive stats updates
+    // Setup stats channel and timeout
     let (tx, mut rx) = mpsc::channel::<RoundTripStats>(32);
-
-    // Create cancellation token with timeout
     let cancel_token = CancellationToken::new();
     let cancel_clone = cancel_token.clone();
-
-    // Spawn timeout task
     let timeout_secs = cli.timeout;
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(timeout_secs)).await;
         cancel_clone.cancel();
     });
 
-    // Run the roundtrip using existing logic
-    println!("[1/2] Deposit: KAS -> Hub");
+    // Run roundtrip in background, print progress from stats
+    let rt_handle = tokio::spawn(async move {
+        do_round_trip(task_resources, kaspa_whale, hub_whale, &tx, 0, cancel_token).await;
+    });
 
-    do_round_trip(task_resources, kaspa_whale, hub_whale, &tx, 0, cancel_token).await;
-
-    // Drain stats channel to get final result
-    drop(tx);
+    // Track progress
+    let mut last_stage = String::new();
     let mut final_stats: Option<RoundTripStats> = None;
+
     while let Some(stats) = rx.recv().await {
+        if stats.stage != last_stage {
+            print_stage(&stats.stage);
+            last_stage = stats.stage.clone();
+        }
         final_stats = Some(stats);
     }
 
-    let result = match final_stats {
-        Some(stats) => RoundtripResult::from_stats(stats),
-        None => RoundtripResult::error("no stats received from roundtrip"),
+    rt_handle.await?;
+
+    // Print result
+    println!();
+    match final_stats {
+        Some(stats) => print_result(&stats),
+        None => {
+            println!("FAILED: no response");
+            Ok(false)
+        }
+    }
+}
+
+fn print_stage(stage: &str) {
+    let msg = match stage {
+        "PreDeposit" => "[1/4] Submitting deposit...",
+        "AwaitingDepositCredit" => "[2/4] Waiting for hub credit...",
+        "PreWithdrawal" => "[3/4] Submitting withdrawal...",
+        "AwaitingWithdrawalCredit" => "[4/4] Waiting for kaspa credit...",
+        "Complete" => "Done",
+        s if s.contains("NotCredited") => return, // error states handled in result
+        _ => return,
     };
-
-    result.print_summary();
-    Ok(result)
+    println!("{}", msg);
 }
 
-/// Result of a roundtrip test
-#[derive(Debug)]
-pub struct RoundtripResult {
-    pub deposit_tx_id: Option<String>,
-    pub deposit_latency_ms: Option<u128>,
-    pub deposit_error: Option<String>,
-    pub withdrawal_tx_id: Option<String>,
-    pub withdrawal_latency_ms: Option<u128>,
-    pub withdrawal_error: Option<String>,
+fn print_result(stats: &RoundTripStats) -> Result<bool> {
+    let deposit_ok = stats.deposit_error.is_none() && stats.deposit_credit_error.is_none();
+    let withdraw_ok = stats.withdrawal_error.is_none() && stats.withdraw_credit_error.is_none();
+
+    let deposit_time = stats
+        .deposit_credit_time_millis
+        .zip(stats.kaspa_deposit_tx_time_millis)
+        .map(|(end, start)| format_duration(end - start));
+
+    let withdraw_time = stats
+        .withdraw_credit_time_millis
+        .zip(stats.hub_withdraw_tx_time_millis)
+        .map(|(end, start)| format_duration(end - start));
+
+    // Deposit result
+    print!("Deposit:    ");
+    if let Some(ref e) = stats.deposit_error {
+        println!("FAILED ({})", e);
+    } else if let Some(ref e) = stats.deposit_credit_error {
+        println!("FAILED ({})", e);
+    } else if let Some(t) = deposit_time {
+        println!("OK ({})", t);
+    } else {
+        println!("INCOMPLETE");
+    }
+
+    // Withdrawal result
+    print!("Withdrawal: ");
+    if !deposit_ok {
+        println!("SKIPPED");
+    } else if let Some(ref e) = stats.withdrawal_error {
+        println!("FAILED ({})", e);
+    } else if let Some(ref e) = stats.withdraw_credit_error {
+        println!("FAILED ({})", e);
+    } else if let Some(t) = withdraw_time {
+        println!("OK ({})", t);
+    } else {
+        println!("INCOMPLETE");
+    }
+
+    Ok(deposit_ok && withdraw_ok && stats.stage == "Complete")
 }
 
-impl RoundtripResult {
-    fn from_stats(stats: RoundTripStats) -> Self {
-        let deposit_latency_ms = stats
-            .deposit_credit_time_millis
-            .and_then(|credit| stats.kaspa_deposit_tx_time_millis.map(|tx| credit - tx));
-
-        let withdrawal_latency_ms = stats
-            .withdraw_credit_time_millis
-            .and_then(|credit| stats.hub_withdraw_tx_time_millis.map(|tx| credit - tx));
-
-        Self {
-            deposit_tx_id: stats.kaspa_deposit_tx_id.map(|id| id.to_string()),
-            deposit_latency_ms,
-            deposit_error: stats.deposit_error.or(stats.deposit_credit_error),
-            withdrawal_tx_id: stats.hub_withdraw_tx_id,
-            withdrawal_latency_ms,
-            withdrawal_error: stats.withdrawal_error.or(stats.withdraw_credit_error),
-        }
-    }
-
-    fn error(msg: &str) -> Self {
-        Self {
-            deposit_tx_id: None,
-            deposit_latency_ms: None,
-            deposit_error: Some(msg.to_string()),
-            withdrawal_tx_id: None,
-            withdrawal_latency_ms: None,
-            withdrawal_error: None,
-        }
-    }
-
-    fn format_duration(ms: u128) -> String {
-        let total_secs = ms / 1000;
-        let mins = total_secs / 60;
-        let secs = total_secs % 60;
-        if mins > 0 {
-            format!("{}min {}sec", mins, secs)
-        } else {
-            format!("{}sec", secs)
-        }
-    }
-
-    pub fn print_summary(&self) {
-        let deposit_status = if let Some(ref err) = self.deposit_error {
-            format!("FAILED ({})", err)
-        } else if let Some(latency) = self.deposit_latency_ms {
-            format!("OK {}", Self::format_duration(latency))
-        } else {
-            "INCOMPLETE".to_string()
-        };
-
-        let withdrawal_status = if let Some(ref err) = self.withdrawal_error {
-            format!("FAILED ({})", err)
-        } else if let Some(latency) = self.withdrawal_latency_ms {
-            format!("OK {}", Self::format_duration(latency))
-        } else if self.deposit_error.is_some() {
-            "SKIPPED (deposit failed)".to_string()
-        } else {
-            "INCOMPLETE".to_string()
-        };
-
-        let deposit_tx_suffix = self
-            .deposit_tx_id
-            .as_ref()
-            .map(|tx| format!(" (tx: {})", tx))
-            .unwrap_or_default();
-        let withdrawal_tx_suffix = self
-            .withdrawal_tx_id
-            .as_ref()
-            .map(|tx| format!(" (tx: {})", tx))
-            .unwrap_or_default();
-
-        println!();
-        println!("=== Summary ===");
-        println!(
-            "Deposit:    KAS -> Hub  {}{}",
-            deposit_status, deposit_tx_suffix
-        );
-        println!(
-            "Withdrawal: Hub -> KAS  {}{}",
-            withdrawal_status, withdrawal_tx_suffix
-        );
-    }
-
-    pub fn is_success(&self) -> bool {
-        self.deposit_error.is_none()
-            && self.withdrawal_error.is_none()
-            && self.deposit_latency_ms.is_some()
-            && self.withdrawal_latency_ms.is_some()
+fn format_duration(ms: u128) -> String {
+    let secs = ms / 1000;
+    if secs >= 60 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else {
+        format!("{}s", secs)
     }
 }

--- a/rust/main/utils/kaspa-tools/src/sim/sim.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/sim.rs
@@ -62,12 +62,9 @@ impl TryFrom<SimulateTrafficCli> for SimulateTrafficArgs {
     type Error = eyre::Error;
 
     fn try_from(cli: SimulateTrafficCli) -> Result<Self, Self::Error> {
-        let addr = kaspa_addresses::Address::try_from(cli.escrow_address.clone())?;
-        let kaspa_network = match cli.kaspa_network.to_lowercase().as_str() {
-            "testnet" => Network::KaspaTest10,
-            "mainnet" => Network::KaspaMainnet,
-            _ => return Err(eyre::eyre!("invalid kaspa network: {}", cli.kaspa_network)),
-        };
+        let escrow_address = cli.bridge.parse_escrow_address()?;
+        let kaspa_network = cli.bridge.parse_kaspa_network()?;
+
         Ok(SimulateTrafficArgs {
             params: Params {
                 time_limit: std::time::Duration::from_secs(cli.time_limit),
@@ -75,26 +72,26 @@ impl TryFrom<SimulateTrafficCli> for SimulateTrafficArgs {
                 max_wait_for_cancel: std::time::Duration::from_secs(cli.cancel_wait),
             },
             task_args: TaskArgs {
-                domain_kas: cli.domain_kas,
-                token_kas_placeholder: cli.token_kas_placeholder,
-                domain_hub: cli.domain_hub,
-                token_hub: cli.token_hub,
-                escrow_address: addr,
-                deposit_amount: cli.deposit_amount,
-                withdrawal_fee_pct: cli.withdrawal_fee_pct,
+                domain_kas: cli.bridge.domain_kas,
+                token_kas_placeholder: cli.bridge.token_kas_placeholder,
+                domain_hub: cli.bridge.domain_hub,
+                token_hub: cli.bridge.token_hub,
+                escrow_address,
+                deposit_amount: cli.bridge.deposit_amount,
+                withdrawal_fee_pct: cli.bridge.withdrawal_fee_pct,
             },
             kaspa_whale_secrets: cli.kaspa_whale_secrets,
             hub_whale_priv_keys: cli.hub_whale_priv_keys,
             kaspa_whale_wallet_dir_prefix: cli.kaspa_whale_wallet_dir_prefix,
-            kaspa_wrpc_url: cli.kaspa_wrpc_url,
+            kaspa_wrpc_url: cli.bridge.kaspa_wrpc_url,
             output_dir: cli.output_dir,
-            hub_rpc_url: cli.hub_rpc_url,
-            hub_grpc_url: cli.hub_grpc_url,
-            hub_chain_id: cli.hub_chain_id,
-            hub_prefix: cli.hub_prefix,
-            hub_denom: cli.hub_denom,
-            hub_decimals: cli.hub_decimals,
-            kaspa_rest_url: cli.kaspa_rest_url,
+            hub_rpc_url: cli.bridge.hub_rpc_url,
+            hub_grpc_url: cli.bridge.hub_grpc_url,
+            hub_chain_id: cli.bridge.hub_chain_id,
+            hub_prefix: cli.bridge.hub_prefix,
+            hub_denom: cli.bridge.hub_denom,
+            hub_decimals: cli.bridge.hub_decimals,
+            kaspa_rest_url: cli.bridge.kaspa_rest_url,
             kaspa_network,
         })
     }

--- a/rust/main/utils/kaspa-tools/src/sim/util.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/util.rs
@@ -1,4 +1,63 @@
+use super::key_cosmos::EasyHubKey;
+use eyre::Result;
+use hyperlane_core::config::OpSubmissionConfig;
+use hyperlane_core::{ContractLocator, HyperlaneDomain, KnownHyperlaneDomain, NativeToken, H256};
+use hyperlane_cosmos::RawCosmosAmount;
+use hyperlane_cosmos::{
+    native::ModuleQueryClient, ConnectionConf as CosmosConnectionConf, CosmosProvider,
+};
+use hyperlane_metric::prometheus_metric::PrometheusClientMetrics;
+use url::Url;
+
 pub const SOMPI_PER_KAS: u64 = 100_000_000;
+
 pub fn som_to_kas(sompi: u64) -> String {
     format!("{} KAS", sompi as f64 / SOMPI_PER_KAS as f64)
+}
+
+pub fn now_millis() -> u128 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time before Unix epoch")
+        .as_millis()
+}
+
+pub async fn create_cosmos_provider(
+    key: &EasyHubKey,
+    rpc_url: &str,
+    grpc_url: &str,
+    chain_id: &str,
+    prefix: &str,
+    denom: &str,
+    decimals: u32,
+) -> Result<CosmosProvider<ModuleQueryClient>> {
+    let conf = CosmosConnectionConf::new(
+        vec![Url::parse(grpc_url).map_err(|e| eyre::eyre!("invalid gRPC URL: {}", e))?],
+        vec![Url::parse(rpc_url).map_err(|e| eyre::eyre!("invalid RPC URL: {}", e))?],
+        chain_id.to_string(),
+        prefix.to_string(),
+        denom.to_string(),
+        RawCosmosAmount {
+            amount: "100000000000.0".to_string(),
+            denom: denom.to_string(),
+        },
+        32,
+        OpSubmissionConfig::default(),
+        NativeToken {
+            decimals,
+            denom: denom.to_string(),
+        },
+        1.0,
+        None,
+    )
+    .map_err(|e| eyre::eyre!(e))?;
+
+    let d = HyperlaneDomain::Known(KnownHyperlaneDomain::Osmosis);
+    let locator = ContractLocator::new(&d, H256::zero());
+    let signer = Some(key.signer());
+    let metrics = PrometheusClientMetrics::default();
+    let chain = None;
+
+    CosmosProvider::<ModuleQueryClient>::new(&conf, &locator, signer, metrics, chain)
+        .map_err(eyre::Report::from)
 }

--- a/rust/main/utils/kaspa-tools/src/x/args.rs
+++ b/rust/main/utils/kaspa-tools/src/x/args.rs
@@ -1,6 +1,8 @@
 use super::deposit::DepositArgs;
 use clap::{Args, Parser, Subcommand};
+use dym_kas_core::wallet::Network;
 use hyperlane_core::H256;
+use kaspa_addresses::Address;
 use kaspa_consensus_core::network::NetworkId;
 use std::str::FromStr;
 
@@ -33,9 +35,20 @@ pub enum Commands {
     Deposit(DepositCli),
     /// Create a relayer
     Relayer,
-    /// Simulate traffic
+    /// Simulation commands (stress test or single roundtrip)
     #[clap(name = "sim")]
-    SimulateTraffic(SimulateTrafficCli),
+    Sim {
+        #[command(subcommand)]
+        action: SimAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum SimAction {
+    /// Stress test with multiple concurrent operations using whale pools
+    Stresstest(SimulateTrafficCli),
+    /// Single roundtrip: deposit from kaspa wallet to hub wallet, then withdraw back
+    Roundtrip(RoundtripCli),
 }
 
 #[derive(Subcommand, Debug)]
@@ -129,73 +142,12 @@ pub struct SimulateTrafficCli {
     #[arg(long, required = true)]
     pub ops_per_minute: u64,
 
-    /// Kaspa HL domain
-    #[arg(long, required = true)]
-    pub domain_kas: u32,
-
-    /// Kaspa HL token placeholder contract addr (e.g. 0x0000000000000000000000000000000000000000000000000000000000000000)
-    #[arg(long, required = true)]
-    pub token_kas_placeholder: H256,
-
-    /// Hub HL domain
-    #[arg(long, required = true)]
-    pub domain_hub: u32,
-
-    /// The HL Warp token ID for kaspa on the Hub
-    #[arg(long, required = true)]
-    pub token_hub: H256,
-
-    /// Kaspa escrow address
-    #[arg(long, required = true)]
-    pub escrow_address: String,
-
-    /// Kaspa wRPC URL
-    #[arg(long, required = true)]
-    pub kaspa_wrpc_url: String,
-
-    /// Hub RPC URL
-    #[arg(long, required = true)]
-    pub hub_rpc_url: String,
-
-    /// Hub gRPC URL
-    #[arg(long, required = true)]
-    pub hub_grpc_url: String,
-
-    /// Hub chain ID
-    #[arg(long, required = true)]
-    pub hub_chain_id: String,
-
-    /// Hub address prefix
-    #[arg(long, required = true)]
-    pub hub_prefix: String,
-
-    /// Hub native denom
-    #[arg(long, required = true)]
-    pub hub_denom: String,
-
-    /// Hub native token decimals
-    #[arg(long, required = true)]
-    pub hub_decimals: u32,
-
-    /// Kaspa REST API URL
-    #[arg(long, required = true)]
-    pub kaspa_rest_url: String,
-
     /// The number of seconds to wait for the simulation to cancel
     #[arg(long, required = true)]
     pub cancel_wait: u64,
 
-    /// Deposit amount in sompi (e.g. 4100000000 for 41 KAS)
-    #[arg(long, required = true)]
-    pub deposit_amount: u64,
-
-    /// Withdrawal fee percentage as decimal in [0,1] (e.g. 0.01 for 1%)
-    #[arg(long, required = true)]
-    pub withdrawal_fee_pct: f64,
-
-    /// Kaspa network (testnet or mainnet)
-    #[arg(long, required = true)]
-    pub kaspa_network: String,
+    #[command(flatten)]
+    pub bridge: CommonBridgeArgs,
 }
 
 #[derive(Args, Debug, Clone)]
@@ -249,4 +201,111 @@ impl DepositCli {
             wallet_dir: self.wallet.wallet_dir.clone(),
         }
     }
+}
+
+/// Shared bridge configuration used by both stress test and roundtrip commands
+#[derive(Args, Debug, Clone)]
+pub struct CommonBridgeArgs {
+    /// Kaspa HL domain
+    #[arg(long, required = true)]
+    pub domain_kas: u32,
+
+    /// Kaspa HL token placeholder contract addr
+    #[arg(long, required = true)]
+    pub token_kas_placeholder: H256,
+
+    /// Hub HL domain
+    #[arg(long, required = true)]
+    pub domain_hub: u32,
+
+    /// The HL Warp token ID for kaspa on the Hub
+    #[arg(long, required = true)]
+    pub token_hub: H256,
+
+    /// Kaspa escrow address
+    #[arg(long, required = true)]
+    pub escrow_address: String,
+
+    /// Kaspa wRPC URL
+    #[arg(long, required = true)]
+    pub kaspa_wrpc_url: String,
+
+    /// Hub RPC URL
+    #[arg(long, required = true)]
+    pub hub_rpc_url: String,
+
+    /// Hub gRPC URL
+    #[arg(long, required = true)]
+    pub hub_grpc_url: String,
+
+    /// Hub chain ID
+    #[arg(long, required = true)]
+    pub hub_chain_id: String,
+
+    /// Hub address prefix
+    #[arg(long, required = true)]
+    pub hub_prefix: String,
+
+    /// Hub native denom
+    #[arg(long, required = true)]
+    pub hub_denom: String,
+
+    /// Hub native token decimals
+    #[arg(long, required = true)]
+    pub hub_decimals: u32,
+
+    /// Kaspa REST API URL
+    #[arg(long, required = true)]
+    pub kaspa_rest_url: String,
+
+    /// Deposit amount in sompi (e.g. 4100000000 for 41 KAS)
+    #[arg(long, required = true)]
+    pub deposit_amount: u64,
+
+    /// Withdrawal fee percentage as decimal in [0,1] (e.g. 0.01 for 1%)
+    #[arg(long, required = true)]
+    pub withdrawal_fee_pct: f64,
+
+    /// Kaspa network (testnet or mainnet)
+    #[arg(long, required = true)]
+    pub kaspa_network: String,
+}
+
+impl CommonBridgeArgs {
+    pub fn parse_kaspa_network(&self) -> eyre::Result<Network> {
+        match self.kaspa_network.to_lowercase().as_str() {
+            "testnet" => Ok(Network::KaspaTest10),
+            "mainnet" => Ok(Network::KaspaMainnet),
+            _ => Err(eyre::eyre!("invalid kaspa network: {}", self.kaspa_network)),
+        }
+    }
+
+    pub fn parse_escrow_address(&self) -> eyre::Result<Address> {
+        Address::try_from(self.escrow_address.clone())
+            .map_err(|e| eyre::eyre!("invalid escrow address: {}", e))
+    }
+}
+
+#[derive(Args, Debug)]
+/// Single roundtrip test: deposit from kaspa wallet to hub wallet, then withdraw back
+/// Uses the same kaspa wallet for deposit source and withdrawal destination
+pub struct RoundtripCli {
+    /// Kaspa wallet secret (password for the wallet keychain)
+    #[arg(long, required = true)]
+    pub kaspa_wallet_secret: String,
+
+    /// Kaspa wallet directory
+    #[arg(long)]
+    pub kaspa_wallet_dir: Option<String>,
+
+    /// Hub wallet private key in hex (for receiving deposit and sending withdrawal)
+    #[arg(long, required = true)]
+    pub hub_priv_key: String,
+
+    /// Timeout in seconds for waiting for deposit/withdrawal confirmation
+    #[arg(long, required = true)]
+    pub timeout: u64,
+
+    #[command(flatten)]
+    pub bridge: CommonBridgeArgs,
 }

--- a/rust/main/utils/kaspa-tools/src/x/args.rs
+++ b/rust/main/utils/kaspa-tools/src/x/args.rs
@@ -35,23 +35,14 @@ pub enum Commands {
     Deposit(DepositCli),
     /// Create a relayer
     Relayer,
-    /// Simulation commands (stress test or single roundtrip)
+    /// Stress test traffic simulation with multiple concurrent operations
     #[clap(name = "sim")]
-    Sim {
-        #[command(subcommand)]
-        action: SimAction,
-    },
+    Sim(SimulateTrafficCli),
+    /// Single roundtrip test: deposit from kaspa to hub, then withdraw back
+    Roundtrip(RoundtripCli),
     /// Decode a Kaspa withdrawal tx payload to extract Hyperlane message IDs
     #[clap(name = "decode-payload")]
     DecodePayload(DecodePayloadCli),
-}
-
-#[derive(Subcommand, Debug)]
-pub enum SimAction {
-    /// Stress test with multiple concurrent operations using whale pools
-    Stresstest(SimulateTrafficCli),
-    /// Single roundtrip: deposit from kaspa wallet to hub wallet, then withdraw back
-    Roundtrip(RoundtripCli),
 }
 
 #[derive(Subcommand, Debug)]


### PR DESCRIPTION
## Summary

Add `kaspa-tools sim roundtrip` command for single roundtrip testing (deposit from Kaspa to Hub, then withdraw back) that properly reuses existing infrastructure instead of duplicating code.

This is an alternative approach to #407 that achieves the same functionality in a DRY way.

### Key Changes

- **Extract shared utilities to `util.rs`**: `create_cosmos_provider()` and `now_millis()` are now shared between stress test and roundtrip
- **Create `CommonBridgeArgs`**: Shared CLI argument struct used by both `SimulateTrafficCli` and `RoundtripCli` via `#[command(flatten)]`
- **New `roundtrip.rs`**: Thin orchestration layer (~250 lines) that wraps existing `do_round_trip()` logic instead of reimplementing it
- **Update `SimulateTrafficCli`**: Now uses `CommonBridgeArgs` instead of duplicating 16 fields

### Comparison with #407

| Metric | PR #407 | This PR |
|--------|---------|---------|
| New lines | ~640 | ~470 |
| Code duplication | High (repeated balance polling, provider creation, withdrawal logic) | Minimal (reuses existing round_trip.rs) |
| CLI args | Duplicated 16 fields | Shared via CommonBridgeArgs |

### Usage

```bash
kaspa-tools sim roundtrip \
  --kaspa-wallet-secret <secret> \
  --hub-priv-key <hex> \
  --timeout 300 \
  --domain-kas <n> --domain-hub <n> \
  --token-kas-placeholder <h256> --token-hub <h256> \
  --escrow-address <kaspa-addr> \
  --kaspa-wrpc-url <url> --kaspa-rest-url <url> \
  --hub-rpc-url <url> --hub-grpc-url <url> \
  --hub-chain-id <id> --hub-prefix dym --hub-denom adym \
  --hub-decimals 18 \
  --deposit-amount <sompi> --withdrawal-fee-pct 0.01 \
  --kaspa-network testnet
```

## Test plan

- [ ] Run `cargo build -p kaspa-tools` - compiles with no warnings
- [ ] Run `kaspa-tools sim --help` - shows both stresstest and roundtrip subcommands
- [ ] Test roundtrip command against testnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)