### PR TITLE
refactor(kaspa-tools): improve error handling and API design

### DIFF
--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -1,9 +1,15 @@
 use clap::Parser;
-use x::args::{Cli, Commands, ValidatorAction, ValidatorBackend};
+use x::args::{Cli, Commands, SimulateTrafficCli, ValidatorAction, ValidatorBackend};
 
 mod sim;
 use sim::{SimulateTrafficArgs, TrafficSim};
 mod x;
+
+async fn run_sim(args: SimulateTrafficCli) -> eyre::Result<()> {
+    let sim = SimulateTrafficArgs::try_from(args)?;
+    let sim = TrafficSim::new(sim).await?;
+    sim.run().await
+}
 
 async fn run(cli: Cli) {
     tracing_subscriber::fmt::init();
@@ -53,18 +59,17 @@ async fn run(cli: Cli) {
             println!("Relayer private key: {}", signer.private_key);
         }
         Commands::Sim(args) => {
-            let sim = SimulateTrafficArgs::try_from(args).unwrap();
-            let sim = TrafficSim::new(sim).await.unwrap();
-            sim.run().await.unwrap();
-        }
-        Commands::Roundtrip(args) => match sim::roundtrip::do_roundtrip(args).await {
-            Ok(true) => {}
-            Ok(false) => std::process::exit(1),
-            Err(e) => {
-                eprintln!("error: {}", e);
+            if let Err(e) = run_sim(args).await {
+                eprintln!("error: {e}");
                 std::process::exit(1);
             }
-        },
+        }
+        Commands::Roundtrip(args) => {
+            if let Err(e) = sim::roundtrip::do_roundtrip(args).await {
+                eprintln!("error: {e}");
+                std::process::exit(1);
+            }
+        }
         Commands::DecodePayload(args) => {
             if let Err(e) = x::decode_payload::decode_payload(&args.payload) {
                 eprintln!("decode payload: {e}");

--- a/rust/main/utils/kaspa-tools/src/sim/mod.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/mod.rs
@@ -1,10 +1,10 @@
-pub mod hub_whale_pool;
-pub mod kaspa_whale_pool;
-pub mod key_cosmos;
+mod hub_whale_pool;
+mod kaspa_whale_pool;
+mod key_cosmos;
 mod key_kaspa;
-pub mod round_trip;
+mod round_trip;
 pub mod roundtrip;
 mod sim;
-pub mod stats;
-pub mod util;
+mod stats;
+mod util;
 pub use sim::*;

--- a/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
+++ b/rust/main/utils/kaspa-tools/src/sim/roundtrip.rs
@@ -18,7 +18,7 @@ use tokio::sync::mpsc;
 use tokio::sync::Mutex as AsyncMutex;
 use tokio_util::sync::CancellationToken;
 
-pub async fn do_roundtrip(cli: RoundtripCli) -> Result<bool> {
+pub async fn do_roundtrip(cli: RoundtripCli) -> Result<()> {
     let kaspa_network = cli.bridge.parse_kaspa_network()?;
     let escrow_address = cli.bridge.parse_escrow_address()?;
 
@@ -123,13 +123,11 @@ pub async fn do_roundtrip(cli: RoundtripCli) -> Result<bool> {
 
     // Print result
     println!();
-    match final_stats {
-        Some(stats) => print_result(&stats),
-        None => {
-            println!("FAILED: no response");
-            Ok(false)
-        }
-    }
+    let Some(stats) = final_stats else {
+        println!("FAILED: no response");
+        return Err(eyre::eyre!("no stats received"));
+    };
+    print_result(&stats)
 }
 
 fn print_stage(stage: &str) {
@@ -145,7 +143,7 @@ fn print_stage(stage: &str) {
     println!("{}", msg);
 }
 
-fn print_result(stats: &RoundTripStats) -> Result<bool> {
+fn print_result(stats: &RoundTripStats) -> Result<()> {
     let deposit_ok = stats.deposit_error.is_none() && stats.deposit_credit_error.is_none();
     let withdraw_ok = stats.withdrawal_error.is_none() && stats.withdraw_credit_error.is_none();
 
@@ -185,7 +183,11 @@ fn print_result(stats: &RoundTripStats) -> Result<bool> {
         println!("INCOMPLETE");
     }
 
-    Ok(deposit_ok && withdraw_ok && stats.stage == "Complete")
+    if deposit_ok && withdraw_ok && stats.stage == "Complete" {
+        Ok(())
+    } else {
+        Err(eyre::eyre!("roundtrip failed"))
+    }
 }
 
 fn format_duration(ms: u128) -> String {


### PR DESCRIPTION
## Summary

Improvements to PR #413 addressing code review feedback.

### Changes

- **Consistent error handling**: Replace `unwrap()` panics with proper error propagation using `?` operator
- **Cleaner API**: Change `do_roundtrip()` return type from `Result<bool>` to `Result<()>` - the bool was redundant since failure is now represented by the Err variant
- **Idiomatic Rust**: Use `let-else` pattern instead of nested `match` for cleaner control flow
- **Reduced visibility**: Changed unnecessary `pub mod` to private `mod` to minimize public API surface (only `roundtrip` module needs to be public)

### Review feedback addressed

From the code review:
1. ✅ Major #1: Inconsistent error handling between `Sim` and `Roundtrip` commands
2. ✅ Major #2: `Result<bool>` return type when `Result<()>` suffices  
3. ✅ Major #3: Nested match could use `let-else`
4. ✅ Major #4: Over-exported internal modules

## Test plan

- Verified `cargo check -p kaspa-tools` compiles with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)