### PR TITLE
chore: fixed cargo warning

### DIFF
--- a/rust/main/applications/hyperlane-warp-route/Cargo.toml
+++ b/rust/main/applications/hyperlane-warp-route/Cargo.toml
@@ -1,4 +1,3 @@
-cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "hyperlane-warp-route"

--- a/rust/main/hyperlane-core/Cargo.toml
+++ b/rust/main/hyperlane-core/Cargo.toml
@@ -1,4 +1,3 @@
-cargo-features = ["workspace-inheritance"]
 
 [package]
 name = "hyperlane-core"

--- a/rust/sealevel/client/Cargo.toml
+++ b/rust/sealevel/client/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-client"

--- a/rust/sealevel/libraries/access-control/Cargo.toml
+++ b/rust/sealevel/libraries/access-control/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "access-control"

--- a/rust/sealevel/libraries/account-utils/Cargo.toml
+++ b/rust/sealevel/libraries/account-utils/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "account-utils"

--- a/rust/sealevel/libraries/ecdsa-signature/Cargo.toml
+++ b/rust/sealevel/libraries/ecdsa-signature/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "ecdsa-signature"

--- a/rust/sealevel/libraries/hyperlane-sealevel-connection-client/Cargo.toml
+++ b/rust/sealevel/libraries/hyperlane-sealevel-connection-client/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-connection-client"

--- a/rust/sealevel/libraries/hyperlane-sealevel-token/Cargo.toml
+++ b/rust/sealevel/libraries/hyperlane-sealevel-token/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token-lib"

--- a/rust/sealevel/libraries/interchain-security-module-interface/Cargo.toml
+++ b/rust/sealevel/libraries/interchain-security-module-interface/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-interchain-security-module-interface"

--- a/rust/sealevel/libraries/message-recipient-interface/Cargo.toml
+++ b/rust/sealevel/libraries/message-recipient-interface/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-message-recipient-interface"

--- a/rust/sealevel/libraries/multisig-ism/Cargo.toml
+++ b/rust/sealevel/libraries/multisig-ism/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "multisig-ism"

--- a/rust/sealevel/libraries/serializable-account-meta/Cargo.toml
+++ b/rust/sealevel/libraries/serializable-account-meta/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "serializable-account-meta"

--- a/rust/sealevel/libraries/test-transaction-utils/Cargo.toml
+++ b/rust/sealevel/libraries/test-transaction-utils/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-test-transaction-utils"

--- a/rust/sealevel/libraries/test-utils/Cargo.toml
+++ b/rust/sealevel/libraries/test-utils/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-test-utils"

--- a/rust/sealevel/programs/helloworld/Cargo.toml
+++ b/rust/sealevel/programs/helloworld/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-hello-world"

--- a/rust/sealevel/programs/hyperlane-sealevel-igp-test/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp-test/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-igp-test"

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-igp"

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral-memo/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral-memo/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token-collateral-memo"

--- a/rust/sealevel/programs/hyperlane-sealevel-token-collateral/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-collateral/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token-collateral"

--- a/rust/sealevel/programs/hyperlane-sealevel-token-memo/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-memo/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token-memo"

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native-memo/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native-memo/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token-native-memo"

--- a/rust/sealevel/programs/hyperlane-sealevel-token-native/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token-native/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token-native"

--- a/rust/sealevel/programs/hyperlane-sealevel-token/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-token/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-token"

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-multisig-ism-message-id"

--- a/rust/sealevel/programs/ism/test-ism/Cargo.toml
+++ b/rust/sealevel/programs/ism/test-ism/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-test-ism"

--- a/rust/sealevel/programs/mailbox-test/Cargo.toml
+++ b/rust/sealevel/programs/mailbox-test/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-mailbox-test"

--- a/rust/sealevel/programs/mailbox/Cargo.toml
+++ b/rust/sealevel/programs/mailbox/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-mailbox"

--- a/rust/sealevel/programs/test-send-receiver/Cargo.toml
+++ b/rust/sealevel/programs/test-send-receiver/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-test-send-receiver"

--- a/rust/sealevel/programs/validator-announce/Cargo.toml
+++ b/rust/sealevel/programs/validator-announce/Cargo.toml
@@ -1,4 +1,4 @@
-cargo-features = ["workspace-inheritance"]
+
 
 [package]
 name = "hyperlane-sealevel-validator-announce"


### PR DESCRIPTION
fixed this warning when compiling:
```
warning: /Users/mtsitrin/Applications/dymension/hyperlane-monorepo/rust/sealevel/libraries/ecdsa-signature/Cargo.toml: the cargo feature `workspace-inheritance` has been stabilized in the 1.64 release and is no longer necessary to be listed in the manifest
  See https://doc.rust-lang.org/cargo/reference/unstable.html#workspace-inheritance for more information about using this feature.
```