### PR TITLE
claude: chore(kaspa): remove unused Foo error variant

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/error.rs
+++ b/rust/main/chains/dymension-kaspa/src/error.rs
@@ -45,8 +45,6 @@ pub enum HyperlaneKaspaError {
     ParsingFailed(String),
     #[error("Parsing attempt failed. (Errors: {0:?})")]
     ParsingAttemptsFailed(Vec<HyperlaneKaspaError>),
-    #[error("{0}")]
-    Foo(String),
 }
 
 impl From<HyperlaneKaspaError> for ChainCommunicationError {


### PR DESCRIPTION
## Summary
- Remove the unused `Foo(String)` variant from `HyperlaneKaspaError` enum
- This variant is only defined but never used anywhere in the codebase

## Test plan
- [x] cargo check passes
- [ ] CI validates build

🤖 Generated with [Claude Code](https://claude.com/claude-code)