### PR TITLE
refactor(kaspa): unify MustMatch validation pattern

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/kas_validator/error.rs
+++ b/rust/main/chains/dymension-kaspa/src/kas_validator/error.rs
@@ -1,3 +1,4 @@
+use hyperlane_core::HyperlaneMessage;
 use kaspa_consensus_core::tx::TransactionOutpoint;
 
 #[derive(Debug, thiserror::Error)]
@@ -150,4 +151,49 @@ pub enum ValidationError {
 
     #[error("Finality check error: tx_id={tx_id} reason={reason}")]
     FinalityCheckError { tx_id: String, reason: String },
+}
+
+/// Validate that a HyperlaneMessage matches expected static fields.
+/// Checks version, origin, sender, destination, and recipient.
+/// Nonce and body are not checked as they vary per message.
+pub fn validate_hl_message_fields(
+    expected: &HyperlaneMessage,
+    actual: &HyperlaneMessage,
+) -> Result<(), ValidationError> {
+    if expected.version != actual.version {
+        return Err(ValidationError::HLMessageFieldMismatch {
+            field: "version".to_string(),
+            expected: expected.version.to_string(),
+            actual: actual.version.to_string(),
+        });
+    }
+    if expected.origin != actual.origin {
+        return Err(ValidationError::HLMessageFieldMismatch {
+            field: "origin".to_string(),
+            expected: expected.origin.to_string(),
+            actual: actual.origin.to_string(),
+        });
+    }
+    if expected.sender != actual.sender {
+        return Err(ValidationError::HLMessageFieldMismatch {
+            field: "sender".to_string(),
+            expected: format!("{:?}", expected.sender),
+            actual: format!("{:?}", actual.sender),
+        });
+    }
+    if expected.destination != actual.destination {
+        return Err(ValidationError::HLMessageFieldMismatch {
+            field: "destination".to_string(),
+            expected: expected.destination.to_string(),
+            actual: actual.destination.to_string(),
+        });
+    }
+    if expected.recipient != actual.recipient {
+        return Err(ValidationError::HLMessageFieldMismatch {
+            field: "recipient".to_string(),
+            expected: format!("{:?}", expected.recipient),
+            actual: format!("{:?}", actual.recipient),
+        });
+    }
+    Ok(())
 }

--- a/rust/main/chains/dymension-kaspa/src/kas_validator/withdraw.rs
+++ b/rust/main/chains/dymension-kaspa/src/kas_validator/withdraw.rs
@@ -1,7 +1,7 @@
 // We call the signers 'validators'
 
 use crate::consts::ALLOWED_HL_MESSAGE_VERSION;
-use crate::kas_validator::error::ValidationError;
+use crate::kas_validator::error::{validate_hl_message_fields, ValidationError};
 use crate::ops::addr::h256_to_script_pubkey;
 use crate::ops::payload::MessageIDs;
 use crate::ops::withdraw::{filter_pending_withdrawals, WithdrawFXG};
@@ -57,42 +57,7 @@ impl MustMatch {
     }
 
     fn is_match(&self, other: &HyperlaneMessage) -> Result<()> {
-        if self.partial_message.version != other.version {
-            return Err(eyre::eyre!(
-                "version is incorrect, expected: {}, got: {}",
-                self.partial_message.version,
-                other.version
-            ));
-        }
-        if self.partial_message.origin != other.origin {
-            return Err(eyre::eyre!(
-                "origin is incorrect, expected: {}, got: {}",
-                self.partial_message.origin,
-                other.origin
-            ));
-        }
-        if self.partial_message.sender != other.sender {
-            return Err(eyre::eyre!(
-                "sender is incorrect, expected: {}, got: {}",
-                self.partial_message.sender,
-                other.sender
-            ));
-        }
-        if self.partial_message.destination != other.destination {
-            return Err(eyre::eyre!(
-                "destination is incorrect, expected: {}, got: {}",
-                self.partial_message.destination,
-                other.destination
-            ));
-        }
-        if self.partial_message.recipient != other.recipient {
-            return Err(eyre::eyre!(
-                "recipient is incorrect, expected: {}, got: {}",
-                self.partial_message.recipient,
-                other.recipient
-            ));
-        }
-        Ok(())
+        validate_hl_message_fields(&self.partial_message, other).map_err(|e| eyre::eyre!("{}", e))
     }
 }
 


### PR DESCRIPTION
## Summary
- Extract shared HyperlaneMessage field validation into `validate_hl_message_fields` function in `error.rs`
- Both `deposit.rs` and `withdraw.rs` MustMatch structs now use this shared function instead of duplicating validation logic (~70 lines each reduced to 1-2 lines)
- Removes unused `enable_validation` field and `set_validation` method from deposit MustMatch (dead code)

## Test plan
- [x] `cargo build -p dymension-kaspa` passes
- [x] `cargo clippy -p dymension-kaspa` passes (warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)