### PR TITLE
fix(scraper,relayer): update interchain_gas_paymaster to interchain_gas_paymasters

### DIFF
--- a/rust/main/agents/relayer/src/relayer/tests.rs
+++ b/rust/main/agents/relayer/src/relayer/tests.rs
@@ -36,11 +36,11 @@ fn generate_test_core_contract_addresses() -> CoreContractAddresses {
                 .unwrap()
                 .as_slice(),
         ),
-        interchain_gas_paymaster: H256::from_slice(
+        interchain_gas_paymasters: vec![H256::from_slice(
             hex::decode("000000000000000000000000c756cFc1b7d0d4646589EDf10eD54b201237F5e8")
                 .unwrap()
                 .as_slice(),
-        ),
+        )],
         validator_announce: H256::from_slice(
             hex::decode("0000000000000000000000001b33611fCc073aB0737011d5512EF673Bff74962")
                 .unwrap()

--- a/rust/main/agents/scraper/src/agent.rs
+++ b/rust/main/agents/scraper/src/agent.rs
@@ -215,7 +215,12 @@ impl Scraper {
             scraper_db,
             domain.clone(),
             chain_setup.addresses.mailbox,
-            chain_setup.addresses.interchain_gas_paymaster,
+            chain_setup
+                .addresses
+                .interchain_gas_paymasters
+                .first()
+                .cloned()
+                .unwrap_or_default(),
             provider,
             &chain_setup.index.clone(),
         )
@@ -426,13 +431,13 @@ mod test {
                         .unwrap()
                         .as_slice(),
                     ),
-                    interchain_gas_paymaster: H256::from_slice(
+                    interchain_gas_paymasters: vec![H256::from_slice(
                         hex::decode(
                             "000000000000000000000000c756cFc1b7d0d4646589EDf10eD54b201237F5e8",
                         )
                         .unwrap()
                         .as_slice(),
-                    ),
+                    )],
                     validator_announce: H256::from_slice(
                         hex::decode(
                             "0000000000000000000000001b33611fCc073aB0737011d5512EF673Bff74962",


### PR DESCRIPTION
## Summary
- Fix build error caused by field name change in `CoreContractAddresses`
- Update `interchain_gas_paymaster` (singular) to `interchain_gas_paymasters` (plural Vec)
- Scraper now uses `.first().cloned().unwrap_or_default()` to get the first IGP address

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)