### PR TITLE
feat(kaspa): use src/dst escrow model for confirmation validation

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/validator/server.rs
+++ b/rust/main/chains/dymension-kaspa/src/validator/server.rs
@@ -481,7 +481,10 @@ async fn respond_validate_confirmed_withdrawals<
     let conf_fxg: ConfirmationFXG = body.try_into().map_err(|e: eyre::Report| AppError(e))?;
 
     if res.must_val_stuff().toggles.validate_confirmations {
-        validate_confirmed_withdrawals(&conf_fxg, res.must_rest_client(), &res.must_escrow().addr)
+        let src_escrow = &res.must_escrow().addr;
+        let migration_target = res.must_val_stuff().toggles.parsed_migration_target();
+        let dst_escrow = migration_target.as_ref().unwrap_or(src_escrow);
+        validate_confirmed_withdrawals(&conf_fxg, res.must_rest_client(), src_escrow, dst_escrow)
             .await
             .map_err(|e| {
                 eprintln!("Withdrawal confirmation validation failed: {:?}", e);


### PR DESCRIPTION
## Summary

Refactors confirmation validation to use explicit `src_escrow` and `dst_escrow` parameters instead of optional `migration_target_address`. This is a cleaner mental model:

- **Normal operation**: src and dst are the same (current escrow)
- **During migration**: src is old escrow, dst is new escrow

The validation accepts confirmation trace outputs to either address, enabling traces to cross the migration boundary seamlessly.

## Changes

- `validate_confirmed_withdrawals()` now takes `src_escrow` and `dst_escrow` instead of single `escrow_address`
- `escrow_outpoint_in_outputs()` accepts outputs to either src or dst escrow
- Server handler determines dst based on migration mode config

## Test plan

- [x] Code compiles
- [ ] Existing confirmation validation tests pass
- [ ] Manual test with migration scenario

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)