### PR TITLE
feat(kaspa): add migration command for escrow key rotation

### DIFF
--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -74,9 +74,6 @@ pub struct RelayerSettings {
     pub tx_id_indexing_enabled: bool,
     /// Whether to enable IGP indexing.
     pub igp_indexing_enabled: bool,
-    /// If set, run escrow key migration to this address and exit.
-    /// Used for Kaspa escrow key rotation.
-    pub migrate_escrow_to: Option<String>,
 }
 
 /// Config for gas payment enforcement
@@ -372,13 +369,6 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_bool()
             .unwrap_or(true);
 
-        let migrate_escrow_to = p
-            .chain(&mut err)
-            .get_opt_key("migrateEscrowTo")
-            .parse_string()
-            .end()
-            .map(|s| s.to_string());
-
         err.into_result(RelayerSettings {
             base,
             db,
@@ -397,7 +387,6 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             max_retries: max_message_retries,
             tx_id_indexing_enabled,
             igp_indexing_enabled,
-            migrate_escrow_to,
         })
     }
 }

--- a/rust/main/agents/relayer/src/settings/mod.rs
+++ b/rust/main/agents/relayer/src/settings/mod.rs
@@ -74,6 +74,9 @@ pub struct RelayerSettings {
     pub tx_id_indexing_enabled: bool,
     /// Whether to enable IGP indexing.
     pub igp_indexing_enabled: bool,
+    /// If set, run escrow key migration to this address and exit.
+    /// Used for Kaspa escrow key rotation.
+    pub migrate_escrow_to: Option<String>,
 }
 
 /// Config for gas payment enforcement
@@ -369,6 +372,13 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             .parse_bool()
             .unwrap_or(true);
 
+        let migrate_escrow_to = p
+            .chain(&mut err)
+            .get_opt_key("migrateEscrowTo")
+            .parse_string()
+            .end()
+            .map(|s| s.to_string());
+
         err.into_result(RelayerSettings {
             base,
             db,
@@ -387,6 +397,7 @@ impl FromRawConf<RawRelayerSettings> for RelayerSettings {
             max_retries: max_message_retries,
             tx_id_indexing_enabled,
             igp_indexing_enabled,
+            migrate_escrow_to,
         })
     }
 }

--- a/rust/main/chains/dymension-kaspa/src/conf.rs
+++ b/rust/main/chains/dymension-kaspa/src/conf.rs
@@ -96,6 +96,8 @@ pub struct RelayerStuff {
     pub max_sweep_inputs: Option<usize>,
     pub max_sweep_bundle_bytes: usize,
     pub validator_request_timeout: std::time::Duration,
+    /// If set, run escrow key migration to this address and exit.
+    pub migrate_escrow_to: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -183,6 +185,7 @@ impl ConnectionConf {
         kas_tx_fee_multiplier: f64,
         max_sweep_inputs: Option<usize>,
         validator_request_timeout: std::time::Duration,
+        migrate_escrow_to: Option<String>,
     ) -> Self {
         // Extract escrow pub keys for ConnectionConf (used by both validator and relayer)
         let validator_pub_keys: Vec<String> = kaspa_validators
@@ -226,6 +229,7 @@ impl ConnectionConf {
                 max_sweep_inputs,
                 max_sweep_bundle_bytes: 8 * 1024 * 1024,
                 validator_request_timeout,
+                migrate_escrow_to,
             })
         } else {
             None

--- a/rust/main/chains/dymension-kaspa/src/lib.rs
+++ b/rust/main/chains/dymension-kaspa/src/lib.rs
@@ -27,6 +27,7 @@ pub mod validator;
 // Direct reexports of lib stuff:
 pub use consts as hl_domains;
 pub use dym_kas_core;
+pub use kaspa_addresses::Address as KaspaAddress;
 
 // Re-export message module from ops as hl_message for semantic clarity
 pub use ops::message as hl_message;

--- a/rust/main/chains/dymension-kaspa/src/relayer/migration/flow.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/migration/flow.rs
@@ -1,7 +1,10 @@
 use crate::ops::migration::MigrationFXG;
+use crate::ops::payload::MessageIDs;
+use crate::ops::withdraw::query_hub_anchor;
 use crate::providers::KaspaProvider;
 use crate::relayer::withdraw::hub_to_kaspa::{
-    combine_all_bundles, create_pskt, finalize_migration_txs,
+    combine_all_bundles, create_pskt, fetch_input_utxos, finalize_migration_txs,
+    get_normal_bucket_feerate,
 };
 use dym_kas_core::pskt::{PopulatedInput, PopulatedInputBuilder};
 use eyre::{eyre, Result};
@@ -15,10 +18,12 @@ use tracing::info;
 /// Execute escrow key migration.
 ///
 /// This function:
-/// 1. Fetches all UTXOs from the current escrow
-/// 2. Builds a PSKT that transfers all funds to the new escrow
-/// 3. Collects signatures from validators
-/// 4. Combines signatures and broadcasts the transaction
+/// 1. Queries hub for current anchor and fetches all escrow UTXOs
+/// 2. Verifies hub anchor is among escrow UTXOs
+/// 3. Fetches relayer UTXOs to pay transaction fees
+/// 4. Builds a PSKT that transfers all escrow funds to the new escrow (relayer pays fee)
+/// 5. Collects signatures from validators
+/// 6. Combines signatures and broadcasts the transaction
 pub async fn execute_migration(
     provider: &KaspaProvider,
     new_escrow_address: &Address,
@@ -26,9 +31,20 @@ pub async fn execute_migration(
     let escrow = provider.escrow();
     let easy_wallet = provider.wallet();
     let validators_client = provider.validators();
+    let hub_rpc = provider.hub_rpc().query();
     info!("Starting escrow key migration");
 
-    // 1. Fetch all escrow UTXOs
+    // 1. Query hub for current anchor
+    let hub_anchor = query_hub_anchor(hub_rpc)
+        .await
+        .map_err(|e| eyre!("Query hub anchor: {}", e))?;
+    info!(
+        tx_id = %hub_anchor.transaction_id,
+        index = hub_anchor.index,
+        "Got hub anchor"
+    );
+
+    // 2. Fetch all escrow UTXOs
     let escrow_addr = escrow.addr.clone();
     let escrow_utxos = easy_wallet
         .rpc_with_reconnect(|api| {
@@ -45,15 +61,28 @@ pub async fn execute_migration(
         return Err(eyre!("No UTXOs found in escrow address"));
     }
 
-    let total_amount: u64 = escrow_utxos.iter().map(|u| u.utxo_entry.amount).sum();
+    // 3. Verify hub anchor is among escrow UTXOs
+    let hub_anchor_found = escrow_utxos.iter().any(|u| {
+        u.outpoint.transaction_id == hub_anchor.transaction_id
+            && u.outpoint.index == hub_anchor.index
+    });
+    if !hub_anchor_found {
+        return Err(eyre!(
+            "Hub anchor {}:{} not found in escrow UTXOs - state may be stale",
+            hub_anchor.transaction_id,
+            hub_anchor.index
+        ));
+    }
+
+    let escrow_sum: u64 = escrow_utxos.iter().map(|u| u.utxo_entry.amount).sum();
     info!(
         utxo_count = escrow_utxos.len(),
-        total_amount, "Fetched escrow UTXOs for migration"
+        escrow_sum, "Fetched escrow UTXOs for migration"
     );
 
-    // 2. Build migration PSKT
+    // 4. Build escrow inputs
     let sig_op_count = escrow.n() as u8;
-    let inputs: Vec<PopulatedInput> = escrow_utxos
+    let escrow_inputs: Vec<PopulatedInput> = escrow_utxos
         .into_iter()
         .map(|utxo| {
             PopulatedInputBuilder::new(
@@ -69,21 +98,89 @@ pub async fn execute_migration(
         })
         .collect();
 
-    // Single output to new escrow (all funds minus fee buffer)
-    // Fee will be deducted by the network from the total
-    let new_escrow_script = pay_to_address_script(new_escrow_address);
-    let output = TransactionOutput::new(total_amount, new_escrow_script);
+    // 5. Fetch relayer UTXOs for fee payment
+    let relayer_addr = easy_wallet.account().change_address()?;
+    let network_id = easy_wallet.net.network_id;
+    let relayer_addr_clone = relayer_addr.clone();
+    let relayer_inputs = easy_wallet
+        .rpc_with_reconnect(|api| {
+            let addr = relayer_addr_clone.clone();
+            async move {
+                fetch_input_utxos(
+                    &api, &addr, None, // No redeem script for relayer inputs
+                    1,    // sig_op_count for P2PK
+                    network_id,
+                )
+                .await
+            }
+        })
+        .await
+        .map_err(|e| eyre!("Fetch relayer UTXOs: {}", e))?;
 
-    // No payload for migration transactions
-    let pskt = create_pskt(inputs, vec![output], None)?;
+    if relayer_inputs.is_empty() {
+        return Err(eyre!(
+            "Relayer has no UTXOs to pay migration fee - fund relayer address first"
+        ));
+    }
+
+    let relayer_sum: u64 = relayer_inputs
+        .iter()
+        .map(|(_, entry, _)| entry.amount)
+        .sum();
+    info!(
+        relayer_utxo_count = relayer_inputs.len(),
+        relayer_sum, "Fetched relayer UTXOs for fee"
+    );
+
+    // 6. Calculate fee
+    let feerate = easy_wallet
+        .rpc_with_reconnect(|api| async move { get_normal_bucket_feerate(&api).await })
+        .await?;
+
+    // Estimate transaction mass (escrow inputs are heavier due to multisig)
+    let num_inputs = escrow_inputs.len() + relayer_inputs.len();
+    let num_outputs = 2; // migration target + relayer change
+    let estimated_mass = estimate_migration_tx_mass(escrow_inputs.len(), relayer_inputs.len());
+    let tx_fee = (estimated_mass as f64 * feerate).round() as u64;
+
+    if relayer_sum <= tx_fee {
+        return Err(eyre!(
+            "Relayer balance {} insufficient for fee {}",
+            relayer_sum,
+            tx_fee
+        ));
+    }
+    let relayer_change = relayer_sum - tx_fee;
+
+    info!(
+        feerate,
+        estimated_mass, tx_fee, relayer_change, "Calculated migration fee"
+    );
+
+    // 7. Build inputs: escrow + relayer
+    let mut inputs = escrow_inputs;
+    inputs.extend(relayer_inputs);
+
+    // 8. Build outputs: migration target (100% escrow funds) + relayer change
+    let new_escrow_script = pay_to_address_script(new_escrow_address);
+    let relayer_change_script = pay_to_address_script(&relayer_addr);
+    let outputs = vec![
+        TransactionOutput::new(escrow_sum, new_escrow_script),
+        TransactionOutput::new(relayer_change, relayer_change_script),
+    ];
+
+    // 9. Build PSKT with empty MessageIDs payload (required by validation)
+    let empty_payload = MessageIDs::new(vec![]).to_bytes();
+    let pskt = create_pskt(inputs, outputs, Some(empty_payload))?;
     let bundle = Bundle::from(pskt);
     let fxg = MigrationFXG::new(bundle);
 
-    info!("Built migration PSKT, collecting validator signatures");
+    info!(
+        num_inputs,
+        num_outputs, escrow_sum, "Built migration PSKT, collecting validator signatures"
+    );
 
-    // 3. Collect signatures from validators
-    // Note: get_migration_sigs uses collect_with_threshold internally,
-    // which already enforces the threshold requirement before returning
+    // 10. Collect signatures from validators
     let bundles = validators_client
         .get_migration_sigs(Arc::new(fxg))
         .await
@@ -94,8 +191,7 @@ pub async fn execute_migration(
         "Collected validator signatures"
     );
 
-    // 4. Combine signatures
-
+    // 11. Combine signatures and finalize
     let combined = combine_all_bundles(bundles)?;
     let finalized = finalize_migration_txs(
         combined,
@@ -109,7 +205,7 @@ pub async fn execute_migration(
         "Finalized migration transactions"
     );
 
-    // 5. Submit transactions
+    // 12. Submit transactions
     let mut tx_ids = Vec::new();
     for tx in finalized {
         let tx_clone = tx.clone();
@@ -133,4 +229,24 @@ pub async fn execute_migration(
     );
 
     Ok(tx_ids)
+}
+
+/// Estimate transaction mass for migration.
+/// Escrow inputs are heavier due to multisig redeem script.
+fn estimate_migration_tx_mass(escrow_input_count: usize, relayer_input_count: usize) -> u64 {
+    // Base transaction overhead
+    const BASE_MASS: u64 = 100;
+    // Escrow input mass (multisig with redeem script is heavier)
+    const ESCROW_INPUT_MASS: u64 = 500;
+    // Relayer input mass (simple P2PK)
+    const RELAYER_INPUT_MASS: u64 = 150;
+    // Output mass
+    const OUTPUT_MASS: u64 = 50;
+    // Outputs: migration target + relayer change
+    const NUM_OUTPUTS: u64 = 2;
+
+    BASE_MASS
+        + (escrow_input_count as u64 * ESCROW_INPUT_MASS)
+        + (relayer_input_count as u64 * RELAYER_INPUT_MASS)
+        + (NUM_OUTPUTS * OUTPUT_MASS)
 }

--- a/rust/main/chains/dymension-kaspa/src/relayer/migration/flow.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/migration/flow.rs
@@ -1,0 +1,188 @@
+use crate::ops::migration::MigrationFXG;
+use crate::providers::ValidatorsClient;
+use crate::relayer::withdraw::hub_to_kaspa::{combine_all_bundles, finalize_migration_txs};
+use dym_kas_core::escrow::EscrowPublic;
+use dym_kas_core::pskt::input_sighash_type;
+use dym_kas_core::wallet::EasyKaspaWallet;
+use eyre::{eyre, Result};
+use kaspa_addresses::Address;
+use kaspa_consensus_core::tx::{
+    TransactionInput, TransactionOutpoint, TransactionOutput, UtxoEntry,
+};
+use kaspa_txscript::pay_to_address_script;
+use kaspa_wallet_pskt::prelude::*;
+use kaspa_wallet_pskt::pskt::{InputBuilder, OutputBuilder, PSKT};
+use std::sync::Arc;
+use tracing::info;
+
+type PopulatedInput = (TransactionInput, UtxoEntry, Option<Vec<u8>>);
+
+/// Execute escrow key migration.
+///
+/// This function:
+/// 1. Fetches all UTXOs from the current escrow
+/// 2. Builds a PSKT that transfers all funds to the new escrow
+/// 3. Collects signatures from validators
+/// 4. Combines signatures and broadcasts the transaction
+pub async fn execute_migration(
+    validators_client: &ValidatorsClient,
+    easy_wallet: &EasyKaspaWallet,
+    escrow: &EscrowPublic,
+    new_escrow_address: &Address,
+) -> Result<Vec<kaspa_hashes::Hash>> {
+    info!("Starting escrow key migration");
+
+    // 1. Fetch all escrow UTXOs
+    let escrow_addr = escrow.addr.clone();
+    let escrow_utxos = easy_wallet
+        .rpc_with_reconnect(|api| {
+            let addr = escrow_addr.clone();
+            async move {
+                api.get_utxos_by_addresses(vec![addr])
+                    .await
+                    .map_err(|e| eyre!("Fetch escrow UTXOs: {}", e))
+            }
+        })
+        .await?;
+
+    if escrow_utxos.is_empty() {
+        return Err(eyre!("No UTXOs found in escrow address"));
+    }
+
+    let total_amount: u64 = escrow_utxos.iter().map(|u| u.utxo_entry.amount).sum();
+    info!(
+        utxo_count = escrow_utxos.len(),
+        total_amount, "Fetched escrow UTXOs for migration"
+    );
+
+    // 2. Build migration PSKT
+    let sig_op_count = escrow.n() as u8;
+    let inputs: Vec<PopulatedInput> = escrow_utxos
+        .into_iter()
+        .map(|utxo| {
+            let input = TransactionInput::new(
+                TransactionOutpoint::new(utxo.outpoint.transaction_id, utxo.outpoint.index),
+                vec![],
+                0,
+                sig_op_count,
+            );
+            let entry = UtxoEntry::new(
+                utxo.utxo_entry.amount,
+                escrow.p2sh.clone(),
+                utxo.utxo_entry.block_daa_score,
+                utxo.utxo_entry.is_coinbase,
+            );
+            (input, entry, Some(escrow.redeem_script.clone()))
+        })
+        .collect();
+
+    // Single output to new escrow (all funds minus fee buffer)
+    // Fee will be deducted by the network from the total
+    let new_escrow_script = pay_to_address_script(new_escrow_address);
+    let output = TransactionOutput::new(total_amount, new_escrow_script);
+
+    let pskt = create_migration_pskt(inputs, vec![output])?;
+    let bundle = Bundle::from(pskt);
+    let fxg = MigrationFXG::new(bundle);
+
+    info!("Built migration PSKT, collecting validator signatures");
+
+    // 3. Collect signatures from validators
+    let fxg_arc = Arc::new(fxg);
+    let bundles = validators_client
+        .get_migration_sigs(fxg_arc.clone())
+        .await
+        .map_err(|e| eyre!("Collect migration signatures: {}", e))?;
+
+    info!(
+        bundle_count = bundles.len(),
+        "Collected validator signatures"
+    );
+
+    // 4. Combine signatures
+    let threshold = validators_client.multisig_threshold_escrow();
+    if bundles.len() < threshold {
+        return Err(eyre!(
+            "Not enough validator signatures: got {}, need {}",
+            bundles.len(),
+            threshold
+        ));
+    }
+
+    let combined = combine_all_bundles(bundles)?;
+    let finalized = finalize_migration_txs(
+        combined,
+        escrow,
+        easy_wallet.pub_key().await?,
+        easy_wallet.net.network_id,
+    )?;
+
+    info!(
+        tx_count = finalized.len(),
+        "Finalized migration transactions"
+    );
+
+    // 5. Submit transactions
+    let mut tx_ids = Vec::new();
+    for tx in finalized {
+        let tx_clone = tx.clone();
+        let tx_id = easy_wallet
+            .rpc_with_reconnect(|api| {
+                let tx = tx_clone.clone();
+                async move {
+                    api.submit_transaction(tx, false)
+                        .await
+                        .map_err(|e| eyre!("Submit migration TX: {}", e))
+                }
+            })
+            .await?;
+        info!(tx_id = %tx_id, "Submitted migration transaction");
+        tx_ids.push(tx_id);
+    }
+
+    info!(
+        tx_count = tx_ids.len(),
+        "Migration complete, all transactions submitted"
+    );
+
+    Ok(tx_ids)
+}
+
+fn create_migration_pskt(
+    inputs: Vec<PopulatedInput>,
+    outputs: Vec<TransactionOutput>,
+) -> Result<PSKT<Signer>> {
+    let mut pskt = PSKT::<Creator>::default()
+        .set_version(Version::One)
+        .constructor();
+
+    // Add inputs
+    for (input, entry, redeem_script) in inputs.into_iter() {
+        let mut b = InputBuilder::default();
+
+        b.utxo_entry(entry)
+            .previous_outpoint(input.previous_outpoint)
+            .sig_op_count(input.sig_op_count)
+            .sighash_type(input_sighash_type());
+
+        if let Some(script) = redeem_script {
+            b.redeem_script(script);
+        }
+
+        pskt = pskt.input(b.build().map_err(|e| eyre!("Build PSKT input: {}", e))?);
+    }
+
+    // Add outputs
+    for output in outputs.into_iter() {
+        let b = OutputBuilder::default()
+            .amount(output.value)
+            .script_public_key(output.script_public_key)
+            .build()
+            .map_err(|e| eyre!("Build PSKT output: {}", e))?;
+
+        pskt = pskt.output(b);
+    }
+
+    // No payload for migration
+    Ok(pskt.no_more_inputs().no_more_outputs().signer())
+}

--- a/rust/main/chains/dymension-kaspa/src/relayer/migration/mod.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/migration/mod.rs
@@ -1,0 +1,3 @@
+pub mod flow;
+
+pub use flow::execute_migration;

--- a/rust/main/chains/dymension-kaspa/src/relayer/mod.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/mod.rs
@@ -1,9 +1,11 @@
 pub mod confirm;
 pub mod deposit;
 pub mod metrics;
+pub mod migration;
 pub mod withdraw;
 
 // Re-export the main function for easier access
+pub use migration::execute_migration;
 pub use withdraw::messages::on_new_withdrawals;
 
 // Re-export metrics for easier access

--- a/rust/main/chains/dymension-kaspa/src/relayer/withdraw/hub_to_kaspa.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/withdraw/hub_to_kaspa.rs
@@ -415,7 +415,7 @@ async fn sign_relayer_fee(easy_wallet: &EasyKaspaWallet, fxg: &WithdrawFXG) -> R
 }
 
 /// accepts bundle of signer
-fn combine_all_bundles(bundles: Vec<Bundle>) -> Result<Vec<PSKT<Combiner>>> {
+pub fn combine_all_bundles(bundles: Vec<Bundle>) -> Result<Vec<PSKT<Combiner>>> {
     // each bundle is from a different actor (validator or relayer), and is a vector of pskt
     // therefore index i of each vector corresponds to the same TX i
 
@@ -481,6 +481,19 @@ fn finalize_txs(
     let transactions: Vec<RpcTransaction> = transactions_result?;
 
     Ok(transactions)
+}
+
+/// Finalize migration transactions (no relayer fee inputs).
+pub fn finalize_migration_txs(
+    txs_sigs: Vec<PSKT<Combiner>>,
+    escrow: &EscrowPublic,
+    relayer_pub_key: kaspa_bip32::secp256k1::PublicKey,
+    network_id: NetworkId,
+) -> Result<Vec<RpcTransaction>> {
+    txs_sigs
+        .into_iter()
+        .map(|tx| finalize_pskt(tx, escrow, &relayer_pub_key, network_id))
+        .collect()
 }
 
 // used by multisig demo AND real code

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -536,6 +536,13 @@ pub fn build_kaspa_connection_conf(
         .end()
         .unwrap_or(std::time::Duration::from_secs(15));
 
+    let migrate_escrow_to = chain
+        .chain(err)
+        .get_opt_key("migrateEscrowTo")
+        .parse_string()
+        .end()
+        .map(|s| s.to_string());
+
     Some(ChainConnectionConf::Kaspa(
         dymension_kaspa::ConnectionConf::new(
             wallet_secret.to_owned(),
@@ -560,6 +567,7 @@ pub fn build_kaspa_connection_conf(
             kaspa_tx_fee_multiplier,
             max_sweep_inputs,
             validator_request_timeout,
+            migrate_escrow_to,
         ),
     ))
 }


### PR DESCRIPTION
## Summary
- Adds relayer-side migration flow for escrow key rotation
- Implements execute_migration() function that fetches escrow UTXOs, builds migration PSKT, collects validator signatures, combines them, and broadcasts the final transaction
- Adds ValidatorsClient.get_migration_sigs() for parallel signature collection from validators
- Makes combine_all_bundles() and adds finalize_migration_txs() for migration-specific finalization

## Test plan
- [ ] Unit test migration PSKT creation
- [ ] Integration test with mock validators
- [ ] End-to-end test on testnet with real escrow migration

Generated with Claude Code