### PR TITLE
refactor(kaspa): split KaspaValidatorInfo into purpose-specific types

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/providers/validators.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/validators.rs
@@ -53,24 +53,26 @@ impl ValidatorsClient {
             .expect("ValidatorsClient methods require relayer config")
     }
 
-    fn validators_escrow(&self) -> &[crate::KaspaValidatorInfo] {
+    fn validators_escrow(&self) -> &[crate::KaspaValidatorEscrow] {
         &self.relayer_stuff().validators_escrow
     }
 
-    fn validators_ism(&self) -> &[crate::KaspaValidatorInfo] {
+    fn validators_ism(&self) -> &[crate::KaspaValidatorIsm] {
         &self.relayer_stuff().validators_ism
     }
 
-    fn hosts_from(validators: &[crate::KaspaValidatorInfo]) -> Vec<String> {
-        validators.iter().map(|v| v.host.clone()).collect()
-    }
-
     fn hosts_escrow(&self) -> Vec<String> {
-        Self::hosts_from(self.validators_escrow())
+        self.validators_escrow()
+            .iter()
+            .map(|v| v.host.clone())
+            .collect()
     }
 
     fn hosts_ism(&self) -> Vec<String> {
-        Self::hosts_from(self.validators_ism())
+        self.validators_ism()
+            .iter()
+            .map(|v| v.host.clone())
+            .collect()
     }
 
     /// Collects responses from validators until threshold is met.

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -313,13 +313,13 @@ pub fn build_kaspa_connection_conf(
     };
 
     // Parse kaspaValidatorsEscrow and kaspaValidatorsIsm as arrays of validator objects
-    let validators_escrow: Vec<dymension_kaspa::KaspaValidatorInfo> = parse_kaspa_validators(
+    let validators_escrow: Vec<dymension_kaspa::KaspaValidatorEscrow> = parse_kaspa_validators(
         chain,
         err,
         "kaspaValidatorsEscrow",
         "failed to parse kaspaValidatorsEscrow array",
     )?;
-    let validators_ism: Vec<dymension_kaspa::KaspaValidatorInfo> = parse_kaspa_validators(
+    let validators_ism: Vec<dymension_kaspa::KaspaValidatorIsm> = parse_kaspa_validators(
         chain,
         err,
         "kaspaValidatorsIsm",
@@ -880,18 +880,20 @@ pub fn build_radix_connection_conf(
 
 /// Parse a kaspa validators array from config.
 /// Returns empty vec if the field is missing (valid for validator-only configs).
-fn parse_kaspa_validators(
+fn parse_kaspa_validators<T>(
     chain: &ValueParser,
     err: &mut ConfigParsingError,
     key: &str,
     err_msg: &'static str,
-) -> Option<Vec<dymension_kaspa::KaspaValidatorInfo>> {
+) -> Option<Vec<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
     let validators_opt = chain.chain(err).get_opt_key(key).end();
 
     match validators_opt {
         Some(value_parser) => {
-            let validators: Vec<dymension_kaspa::KaspaValidatorInfo> =
-                value_parser.chain(err).parse_value(err_msg).end()?;
+            let validators: Vec<T> = value_parser.chain(err).parse_value(err_msg).end()?;
             Some(validators)
         }
         None => Some(Vec::new()),


### PR DESCRIPTION
## Summary

- Split `KaspaValidatorInfo` into two distinct types: `KaspaValidatorEscrow` and `KaspaValidatorIsm`
- `validators_escrow` now uses `KaspaValidatorEscrow` with only `host` and `escrow_pub` fields
- `validators_ism` now uses `KaspaValidatorIsm` with only `host` and `ism_address` fields
- Made `parse_kaspa_validators` generic to handle both types via `serde::de::DeserializeOwned`

This eliminates unused fields - `validators_escrow` never used `ism_address` and `validators_ism` never used `escrow_pub`.

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)