### PR TITLE
refactor(kaspa): unify migration config into single field

### DIFF
--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -1242,12 +1242,9 @@ impl Relayer {
     }
 
     fn get_migration_target(&self) -> Option<String> {
-        self.dymension_kaspa_args.as_ref().and_then(|args| {
-            args.kas_provider
-                .must_relayer_stuff()
-                .migrate_escrow_to
-                .clone()
-        })
+        self.dymension_kaspa_args
+            .as_ref()
+            .and_then(|args| args.kas_provider.conf().migrate_escrow_to.clone())
     }
 
     async fn run_escrow_migration(&self, target_address: &str) -> Result<Vec<String>> {

--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -348,6 +348,10 @@ impl KaspaProvider {
         self.conf.relayer_stuff.as_ref().unwrap()
     }
 
+    pub fn conf(&self) -> &ConnectionConf {
+        &self.conf
+    }
+
     pub fn grpc_client(&self) -> Option<kaspa_grpc_client::GrpcClient> {
         self.grpc_client.clone()
     }

--- a/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
+++ b/rust/main/hyperlane-base/src/settings/parser/connection_parser.rs
@@ -432,12 +432,6 @@ pub fn build_kaspa_connection_conf(
             .parse_bool()
             .end()
             .unwrap_or(conf.validate_confirmations);
-        conf.migration_target_address = chain
-            .chain(err)
-            .get_opt_key("migrationTargetAddress")
-            .parse_string()
-            .end()
-            .map(|s| s.to_string());
         conf
     };
 


### PR DESCRIPTION
## Summary
- Consolidates `migrationTargetAddress` (validator) and `migrateEscrowTo` (relayer) into a single `migrate_escrow_to` field on `ConnectionConf`
- Both validator and relayer now share the same config field for migration mode
- Removes redundant parsing of `migrationTargetAddress` from connection_parser.rs

## Changes
- `conf.rs`: Moved `migrate_escrow_to` to `ConnectionConf`, added helper methods `is_migration_mode()` and `parsed_migration_target()`
- `connection_parser.rs`: Removed `migrationTargetAddress` parsing
- `provider.rs`: Added `conf()` accessor
- `server.rs`: Updated validator to use `res.conf().is_migration_mode()` instead of `res.must_val_stuff().toggles.is_migration_mode()`
- `relayer.rs`: Updated to use `kas_provider.conf().migrate_escrow_to`

## Test plan
- [ ] Build passes (`cargo build -p relayer -p validator`)
- [ ] Existing configs work unchanged (field name `migrateEscrowTo` is preserved)
- [ ] Migration mode works for both validator and relayer when env var `HYP_CHAINS_KASPA_MIGRATEESCROWTO` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)