### PR TITLE
feat(kaspa): add migration mode visibility to validator

### DIFF
--- a/rust/main/agents/validator/src/validator.rs
+++ b/rust/main/agents/validator/src/validator.rs
@@ -222,6 +222,15 @@ impl BaseAgent for Validator {
 
         if is_kas(&self.origin_chain) {
             let prov = self.dymension_kaspa_args.clone().unwrap().kas_provider;
+
+            let is_migration = prov.conf().is_migration_mode();
+            let migration_target = prov.conf().migrate_escrow_to.as_deref();
+            info!(
+                is_migration_mode = is_migration,
+                migration_target = migration_target,
+                "Kaspa validator mode"
+            );
+
             let signing = dymension_kaspa::ValidatorISMSigningResources::new(
                 Arc::new(self.raw_signer.clone()),
                 self.signer.clone(),


### PR DESCRIPTION
## Summary
- Adds startup log when Kaspa validator initializes, showing migration mode status
- Adds `/migration-status` HTTP endpoint for querying the current mode

## Changes
- `validator.rs`: Log `is_migration_mode` and `migration_target` immediately after Kaspa chain detection
- `server.rs`: Add `/migration-status` GET endpoint returning JSON with `is_migration_mode` (bool) and `migration_target` (optional string)

## Usage

**Startup log:**
```
INFO Kaspa validator mode is_migration_mode=false migration_target=None
```

**Endpoint:**
```bash
curl http://localhost:5001/migration-status
```
Response:
```json
{"is_migration_mode": false, "migration_target": null}
```
or when in migration mode:
```json
{"is_migration_mode": true, "migration_target": "kaspa:qz..."}
```

## Test plan
- [ ] Build passes (`cargo build -p validator`)
- [ ] Startup log appears when running validator against Kaspa chain
- [ ] `/migration-status` endpoint returns correct JSON response

🤖 Generated with [Claude Code](https://claude.com/claude-code)