### PR TITLE
feat(kaspa): log migration config early during startup

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/conf.rs
+++ b/rust/main/chains/dymension-kaspa/src/conf.rs
@@ -231,6 +231,13 @@ impl ConnectionConf {
             None
         };
 
+        // Log early (before tracing is initialized) so migration mode is visible even if wallet connection fails
+        println!(
+            "Kaspa config: is_migration_mode={}, migration_target={:?}",
+            migrate_escrow_to.is_some(),
+            migrate_escrow_to.as_deref()
+        );
+
         Self {
             wallet_secret,
             wallet_dir,


### PR DESCRIPTION
## Summary
- Add early logging of Kaspa migration config in `ConnectionConf` constructor
- Uses `println!` instead of `tracing::info!` because config parsing happens before tracing is initialized
- Shows `is_migration_mode` and `migration_target` even if wallet connection fails

## Motivation
When testing migration mode, the wallet connection can fail before the migration mode log (in `validator.rs:228`) is reached. This makes it hard to verify the env var `HYP_CHAINS_KASPATEST10_MIGRATEESCROWTO` is being picked up correctly.

## Output Example
```
Kaspa config: is_migration_mode=true, migration_target=Some("kaspatest:pz...")
```

## Test plan
- [x] Build validator binary
- [x] Test with `HYP_CHAINS_KASPATEST10_MIGRATEESCROWTO` set - shows `is_migration_mode=true`
- [x] Test without env var - shows `is_migration_mode=false`

🤖 Generated with [Claude Code](https://claude.ai/code)