### PR TITLE
fix(kaspa-tools): improve error message for invalid public keys

### DIFF
--- a/rust/main/utils/kaspa-tools/src/x/escrow.rs
+++ b/rust/main/utils/kaspa-tools/src/x/escrow.rs
@@ -11,7 +11,18 @@ pub fn get_escrow_address(pub_keys: Vec<&str>, required_signatures: u8, env: &st
     };
     let pub_keys = pub_keys
         .iter()
-        .map(|s| PublicKey::from_str(s).unwrap())
+        .enumerate()
+        .map(|(i, s)| {
+            PublicKey::from_str(s).unwrap_or_else(|e| {
+                panic!(
+                    "invalid public key at position {} (0-indexed): '{}' (len={}): {}",
+                    i,
+                    s,
+                    s.len(),
+                    e
+                )
+            })
+        })
         .collect::<Vec<_>>();
     let e = EscrowPublic::from_pubs(pub_keys, prefix, required_signatures);
     e.addr.to_string()


### PR DESCRIPTION
## Summary

- Improves error message when a public key fails to parse in the `escrow` command
- Shows position, key value, and length to help identify the problematic key

## Before
```
called `Result::unwrap()` on an `Err` value: InvalidPublicKey
```

## After
```
invalid public key at position 1 (0-indexed): 'BADKEY123' (len=9): malformed public key
```

## Test plan

- [x] Build kaspa-tools: `cargo build -p kaspa-tools --release`
- [x] Test with bad key: `./target/release/kaspa-tools escrow --env testnet "02aa...,BADKEY,03..." 2`

🤖 Generated with [Claude Code](https://claude.ai/code)