### PR TITLE
fix(kaspa): add serde aliases for flat-cased config keys

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/conf.rs
+++ b/rust/main/chains/dymension-kaspa/src/conf.rs
@@ -20,6 +20,7 @@ use hyperlane_core::{
 #[serde(rename_all = "camelCase")]
 pub struct KaspaValidatorEscrow {
     pub host: String,
+    #[serde(alias = "escrowpub")]
     pub escrow_pub: String,
 }
 
@@ -34,6 +35,7 @@ pub struct KaspaValidatorEscrow {
 #[serde(rename_all = "camelCase")]
 pub struct KaspaValidatorIsm {
     pub host: String,
+    #[serde(alias = "ismaddress")]
     pub ism_address: String,
 }
 


### PR DESCRIPTION
## Summary
- Adds serde aliases for `escrowpub` and `ismaddress` to handle flat-cased config keys
- Fixes validator config parsing failure when loading configs via the config library's CaseAdapter

## Problem
The config library's `CaseAdapter` converts all JSON keys to flat case (e.g., `escrowPub` → `escrowpub`), but the `KaspaValidatorEscrow` and `KaspaValidatorIsm` structs expect camelCase keys via `#[serde(rename_all = "camelCase")]`. This caused the error:

```
error: failed to parse kaspaValidatorsEscrow array
Caused by: missing field `escrowPub`
```

## Test plan
- [x] Built validator with fix
- [x] Tested with Victor's validator config that previously failed
- [x] Confirmed all 15 escrow public keys are parsed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)