### PR TITLE
fix(kaspa): use relayer_sum for migration mass estimation placeholder

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/relayer/migration/flow.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/migration/flow.rs
@@ -136,12 +136,12 @@ pub async fn execute_migration(
     inputs.extend(relayer_inputs);
     let num_inputs = inputs.len();
 
-    // 7. Build placeholder outputs to calculate mass (amounts don't affect mass)
+    // 7. Build placeholder outputs to estimate mass (storage mass divides by output amount)
     let new_escrow_script = pay_to_address_script(new_escrow_address);
     let relayer_change_script = pay_to_address_script(&relayer_addr);
     let placeholder_outputs = vec![
         TransactionOutput::new(escrow_sum, new_escrow_script.clone()),
-        TransactionOutput::new(0, relayer_change_script.clone()), // placeholder
+        TransactionOutput::new(relayer_sum, relayer_change_script.clone()),
     ];
 
     // 8. Calculate actual mass using Kaspa's mass calculator


### PR DESCRIPTION
## Summary
- Fixed divide-by-zero panic in escrow migration mass estimation
- KIP-0009 storage mass divides by output amounts, so using `0` as the relayer change placeholder caused a panic at `mass/mod.rs:362`
- Use `relayer_sum` instead, matching the pattern in the withdrawal sweep flow's `create_test_outputs()`

## Test plan
- [ ] Deploy to blumbus and re-run Phase 5 migration
- [ ] Verify relayer no longer panics at mass estimation step
- [ ] Confirm migration TX is submitted successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)