### PR TITLE
fix(kaspa): handle null payload in transaction trace

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/relayer/confirm/confirmation.rs
+++ b/rust/main/chains/dymension-kaspa/src/relayer/confirm/confirmation.rs
@@ -132,14 +132,10 @@ async fn recursive_trace_transactions(
         }
 
         /* ------------ the input is part of the lineage! ------------ */
-        let payload = tx
-            .payload
-            .clone()
-            .ok_or_else(|| eyre::eyre!("No payload found in transaction"))?;
-
-        let message_ids = crate::ops::payload::MessageIDs::from_tx_payload(&payload)?;
-
-        processed_withdrawals.extend(message_ids.0);
+        if let Some(payload) = tx.payload.clone() {
+            let message_ids = crate::ops::payload::MessageIDs::from_tx_payload(&payload)?;
+            processed_withdrawals.extend(message_ids.0);
+        }
         outpoint_sequence.push(out_curr);
         return Ok(());
     }


### PR DESCRIPTION
## Summary
- Migration transactions have no payload (empty `MessageIDs` encodes to zero bytes → Kaspa stores as null)
- The trace function (`recursive_trace_transactions`) required a non-null payload and would error with "No payload found in transaction"
- Fix: treat null payload as empty — no message IDs to extract, which is correct for migration TXs

## Context
After migration, the post-migration sync traces the new escrow UTXO back to the old hub anchor via the migration TX. The migration TX has no withdrawal messages (just moves funds), so its payload is null.

## Test plan
- [ ] Deploy to blumbus with REST API pointing to `api-tn10.kaspa.org`
- [ ] Verify trace succeeds through the migration TX (null payload handled)
- [ ] Verify hub anchor is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)