### PR TITLE
feat(kaspa): add escrow_pub to validator-info response

### DIFF
--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -314,6 +314,10 @@ impl KaspaProvider {
             .expect("Kaspa key source not configured")
     }
 
+    pub fn try_kas_key_source(&self) -> Option<&crate::conf::KaspaEscrowKeySource> {
+        self.kas_key_source.as_ref()
+    }
+
     pub fn rest(&self) -> &RestProvider {
         &self.rest
     }


### PR DESCRIPTION
## Summary
- Extend `/validator-info` endpoint to return both ISM address and escrow public key
- Both fields are now optional to support validators with only ISM key, only escrow key, or both
- The `escrow_pub` is the compressed secp256k1 public key (33 bytes hex)

Example responses:

**ISM-only validator:**
```json
{"ism_address": "0xa8f4c60ca8143b8eed67980b0e7e794d3d96039a"}
```

**Escrow-only validator:**
```json
{"escrow_pub": "02aa1e8aad8f1894703c8bfcba0b725512143b6f714305590af83462e5f8a5d709"}
```

**Full validator (both keys):**
```json
{
  "ism_address": "0xa8f4c60ca8143b8eed67980b0e7e794d3d96039a",
  "escrow_pub": "02aa1e8aad8f1894703c8bfcba0b725512143b6f714305590af83462e5f8a5d709"
}
```

## Test plan
- [ ] Build passes: `cargo check -p dymension-kaspa`
- [ ] Test with validator that has both keys configured
- [ ] Test with validator that has only ISM key
- [ ] Test with validator that has only escrow key

🤖 Generated with [Claude Code](https://claude.com/claude-code)