### PR TITLE
feat(kaspa-tools): add compute-deposit-id command

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -7818,6 +7818,7 @@ dependencies = [
  "kaspa-addresses",
  "kaspa-consensus-core",
  "kaspa-core",
+ "kaspa-hashes",
  "kaspa-wallet-core",
  "kaspa-wallet-keys",
  "rand 0.8.5",

--- a/rust/main/utils/kaspa-tools/Cargo.toml
+++ b/rust/main/utils/kaspa-tools/Cargo.toml
@@ -21,6 +21,7 @@ kaspa-wallet-core = { workspace = true }
 kaspa-wallet-keys = { workspace = true }
 kaspa-consensus-core = { workspace = true }
 kaspa-addresses = { workspace = true }
+kaspa-hashes = { workspace = true }
 workflow-core = { workspace = true }
 uuid = { version = "1.11", features = ["v4"] }
 hyperlane-core = { path = "../../hyperlane-core", features = ["ethers"] }

--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -76,6 +76,16 @@ async fn run(cli: Cli) {
                 std::process::exit(1);
             }
         }
+        Commands::ComputeDepositId(args) => {
+            if let Err(e) = x::compute_deposit_id::compute_deposit_id(
+                &args.payload,
+                &args.tx_id,
+                args.utxo_index,
+            ) {
+                eprintln!("compute deposit id: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 }
 

--- a/rust/main/utils/kaspa-tools/src/x/args.rs
+++ b/rust/main/utils/kaspa-tools/src/x/args.rs
@@ -43,6 +43,9 @@ pub enum Commands {
     /// Decode a Kaspa withdrawal tx payload to extract Hyperlane message IDs
     #[clap(name = "decode-payload")]
     DecodePayload(DecodePayloadCli),
+    /// Compute the Hyperlane message ID for a Kaspa deposit transaction
+    #[clap(name = "compute-deposit-id")]
+    ComputeDepositId(ComputeDepositIdCli),
 }
 
 #[derive(Subcommand, Debug)]
@@ -310,4 +313,18 @@ pub struct DecodePayloadCli {
     /// This is the payload field from a Kaspa withdrawal transaction.
     #[arg(required = true, index = 1)]
     pub payload: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ComputeDepositIdCli {
+    /// The deposit payload (hex string, with or without 0x prefix).
+    /// This is the HyperlaneMessage payload from a Kaspa deposit transaction.
+    #[arg(required = true, index = 1)]
+    pub payload: String,
+    /// The Kaspa transaction ID (hex string, with or without 0x prefix).
+    #[arg(required = true, index = 2)]
+    pub tx_id: String,
+    /// The UTXO index of the deposit output in the transaction.
+    #[arg(required = true, index = 3)]
+    pub utxo_index: usize,
 }

--- a/rust/main/utils/kaspa-tools/src/x/compute_deposit_id.rs
+++ b/rust/main/utils/kaspa-tools/src/x/compute_deposit_id.rs
@@ -1,0 +1,80 @@
+use dymension_kaspa::ops::message::{add_kaspa_metadata_hl_messsage, ParsedHL};
+use eyre::Result;
+use kaspa_hashes::Hash;
+
+use std::str::FromStr as _;
+
+/// Compute the Hyperlane message ID for a Kaspa deposit.
+///
+/// The message ID is deterministically derived from the deposit payload combined
+/// with the Kaspa transaction metadata (tx_id, utxo_index). This allows verifying
+/// whether a deposit has been processed on the Dymension hub.
+pub fn compute_deposit_id(payload: &str, tx_id: &str, utxo_index: usize) -> Result<()> {
+    let payload = payload.strip_prefix("0x").unwrap_or(payload);
+    let tx_id = tx_id.strip_prefix("0x").unwrap_or(tx_id);
+
+    let parsed = ParsedHL::parse_string(payload)?;
+
+    let tx_hash =
+        Hash::from_str(tx_id).map_err(|e| eyre::eyre!("invalid transaction ID: {}", e))?;
+
+    let hl_message_with_metadata = add_kaspa_metadata_hl_messsage(parsed, tx_hash, utxo_index)?;
+
+    let message_id = hl_message_with_metadata.id();
+
+    println!(
+        "Hyperlane Message ID: 0x{}",
+        hex::encode(message_id.as_bytes())
+    );
+    println!();
+    println!("To check delivery on Dymension hub:");
+    println!(
+        "  dymd q hyperlane delivered <mailbox_id> 0x{}",
+        hex::encode(message_id.as_bytes())
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_deposit_id_basic() {
+        // This payload is from the user's real transaction
+        let payload = "03000000014088489d00000000000000000000000000000000000000000000000000000000000000005d990b31726f757465725f617070000000000000000000000000000200000000000000000000000000000000000000005b1ae7408e939e381f1d39b8d5dbe9aae7653453000000000000000000000000000000000000000000000000000000174876e800";
+        let tx_id = "242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79";
+        let utxo_index = 0;
+
+        let result = compute_deposit_id(payload, tx_id, utxo_index);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compute_deposit_id_with_0x_prefix() {
+        let payload = "0x03000000014088489d00000000000000000000000000000000000000000000000000000000000000005d990b31726f757465725f617070000000000000000000000000000200000000000000000000000000000000000000005b1ae7408e939e381f1d39b8d5dbe9aae7653453000000000000000000000000000000000000000000000000000000174876e800";
+        let tx_id = "0x242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79";
+        let utxo_index = 0;
+
+        let result = compute_deposit_id(payload, tx_id, utxo_index);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compute_deposit_id_invalid_payload() {
+        let result = compute_deposit_id(
+            "invalid_hex",
+            "242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79",
+            0,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compute_deposit_id_invalid_tx_id() {
+        let payload = "03000000014088489d00000000000000000000000000000000000000000000000000000000000000005d990b31726f757465725f617070000000000000000000000000000200000000000000000000000000000000000000005b1ae7408e939e381f1d39b8d5dbe9aae7653453000000000000000000000000000000000000000000000000000000174876e800";
+        let result = compute_deposit_id(payload, "invalid_tx_id", 0);
+        assert!(result.is_err());
+    }
+}

--- a/rust/main/utils/kaspa-tools/src/x/mod.rs
+++ b/rust/main/utils/kaspa-tools/src/x/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod compute_deposit_id;
 pub mod decode_payload;
 pub mod deposit;
 pub mod escrow;


### PR DESCRIPTION
## Summary
- Adds `compute-deposit-id` command to kaspa-tools that computes the Hyperlane message ID for a Kaspa deposit transaction
- Enables verification of whether a deposit has been processed on the Dymension hub by checking against `dymd q hyperlane delivered`
- Reuses existing `ParsedHL::parse_string` and `add_kaspa_metadata_hl_messsage` from dymension-kaspa crate

## Usage
```bash
kaspa-tools compute-deposit-id <payload> <tx_id> <utxo_index>
```

Example:
```bash
kaspa-tools compute-deposit-id \
  03000000014088489d00...174876e800 \
  242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79 \
  0
```

Output:
```
Hyperlane Message ID: 0x0167144656186f1caaf8a3ef0cd05f25052bbbf8a7433766a6af42d61a5efe5b

To check delivery on Dymension hub:
  dymd q hyperlane delivered <mailbox_id> 0x0167144656186f1caaf8a3ef0cd05f25052bbbf8a7433766a6af42d61a5efe5b
```

## Test plan
- [x] Unit tests pass (`cargo test -p kaspa-tools`)
- [x] Tested with real mainnet deposit transaction payloads
- [x] Handles 0x prefix on payload and tx_id inputs

🤖 Generated with [Claude Code](https://claude.com/claude-code)