### PR TITLE
feat(relayer): add deposit recovery endpoint

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -7818,6 +7818,7 @@ dependencies = [
  "kaspa-addresses",
  "kaspa-consensus-core",
  "kaspa-core",
+ "kaspa-hashes",
  "kaspa-wallet-core",
  "kaspa-wallet-keys",
  "rand 0.8.5",

--- a/rust/main/agents/relayer/src/relayer.rs
+++ b/rust/main/agents/relayer/src/relayer.rs
@@ -585,6 +585,26 @@ impl BaseAgent for Relayer {
             .map(|(key, origin)| (key.id(), origin.prover_sync.clone()))
             .collect();
 
+        // Build kaspa recovery config if available
+        let kaspa_recovery = if let Some(dym_args) = self.dymension_kaspa_args.as_ref() {
+            let sender_guard = dym_args.recovery_sender.read().unwrap();
+            sender_guard
+                .as_ref()
+                .map(|sender| relayer_server::KaspaRecoveryConfig {
+                    sender: sender.clone(),
+                    rest_api_url: dym_args
+                        .kas_provider
+                        .conf()
+                        .kaspa_urls_rest
+                        .first()
+                        .map(|u| u.to_string())
+                        .unwrap_or_default(),
+                    escrow_address: dym_args.kas_provider.escrow_address().to_string(),
+                })
+        } else {
+            None
+        };
+
         let relayer_router = relayer_server::Server::new(self.destinations.len())
             .with_op_retry(sender.clone())
             .with_message_queue(prep_queues)
@@ -596,7 +616,8 @@ impl BaseAgent for Relayer {
                 self.dymension_kaspa_args
                     .as_ref()
                     .and_then(|dym_args| dym_args.kas_provider.kaspa_db().cloned()),
-            ) // Set kaspa_db to server_builder from dymension_args provider if available
+            )
+            .with_kaspa_recovery(kaspa_recovery)
             .router();
 
         let server = self
@@ -1126,6 +1147,9 @@ impl Relayer {
 struct DymensionKaspaArgs {
     kas_provider: Box<KaspaProvider>,
     dym_mailbox: Arc<CosmosNativeMailbox>,
+    /// Sender for deposit recovery requests, populated when Foo is created
+    recovery_sender:
+        Arc<std::sync::RwLock<Option<hyperlane_base::kas_hack::DepositRecoverySender>>>,
 }
 
 // Manual Debug since KaspaMailbox now has a trait object
@@ -1135,6 +1159,7 @@ impl std::fmt::Debug for DymensionKaspaArgs {
             .field("kas_provider", &self.kas_provider)
             .field("kas_mailbox", &"KaspaMailbox")
             .field("dym_mailbox", &self.dym_mailbox)
+            .field("recovery_sender", &"<RwLock>")
             .finish()
     }
 }
@@ -1197,6 +1222,7 @@ impl Relayer {
         Ok(Some(DymensionKaspaArgs {
             kas_provider,
             dym_mailbox,
+            recovery_sender: Arc::new(std::sync::RwLock::new(None)),
         }))
     }
 
@@ -1217,6 +1243,12 @@ impl Relayer {
         let metadata_getter = PendingMessageMetadataGetter::new();
 
         let b = KaspaBridgeFoo::new(kas_provider.clone(), hub_mailbox.clone(), metadata_getter);
+
+        // Store the recovery sender for use by the server endpoint
+        {
+            let mut sender_guard = args.recovery_sender.write().unwrap();
+            *sender_guard = Some(b.recovery_sender());
+        }
 
         // sync relayer before starting other tasks
         b.sync_hub_if_needed().await.unwrap();

--- a/rust/main/agents/relayer/src/server/kaspa/mod.rs
+++ b/rust/main/agents/relayer/src/server/kaspa/mod.rs
@@ -1,19 +1,66 @@
 use std::sync::Arc;
 
-use axum::{routing::get, Router};
-use derive_new::new;
+use axum::{
+    routing::{get, post},
+    Router,
+};
+use dymension_kaspa::dym_kas_core::api::{base::RateLimitConfig, client::HttpClient};
+use hyperlane_base::kas_hack::DepositRecoverySender;
 use hyperlane_core::KaspaDb;
 use tower_http::cors::{Any, CorsLayer};
 
 pub mod list_deposits;
 pub mod list_withdrawals;
+pub mod recover_deposit;
 
-#[derive(Clone, Debug, new)]
+/// Configuration for deposit recovery functionality
+#[derive(Clone)]
+pub struct RecoveryConfig {
+    pub sender: DepositRecoverySender,
+    pub http_client: HttpClient,
+    pub escrow_address: String,
+}
+
+/// Server state for Kaspa endpoints
+#[derive(Clone)]
 pub struct ServerState {
     pub kaspa_db: Arc<dyn KaspaDb>,
+    /// Optional recovery configuration (sender, HTTP client, escrow address)
+    pub recovery: Option<RecoveryConfig>,
+}
+
+impl std::fmt::Debug for ServerState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServerState")
+            .field("kaspa_db", &"<dyn KaspaDb>")
+            .field("recovery", &self.recovery.is_some())
+            .finish()
+    }
 }
 
 impl ServerState {
+    pub fn new(kaspa_db: Arc<dyn KaspaDb>) -> Self {
+        Self {
+            kaspa_db,
+            recovery: None,
+        }
+    }
+
+    pub fn with_recovery(
+        mut self,
+        sender: DepositRecoverySender,
+        rest_api_url: String,
+        escrow_address: String,
+    ) -> Self {
+        let http_client = HttpClient::new(rest_api_url, RateLimitConfig::default());
+        self.recovery = Some(RecoveryConfig {
+            sender,
+            http_client,
+            escrow_address,
+        });
+        self
+    }
+
     pub fn router(self) -> Router {
         let cors = CorsLayer::new()
             .allow_origin(Any)
@@ -23,6 +70,7 @@ impl ServerState {
         Router::new()
             .route("/kaspa/deposit", get(list_deposits::handler))
             .route("/kaspa/withdrawal", get(list_withdrawals::handler))
+            .route("/kaspa/deposit/recover", post(recover_deposit::handler))
             .layer(cors)
             .with_state(self)
     }

--- a/rust/main/agents/relayer/src/server/kaspa/recover_deposit.rs
+++ b/rust/main/agents/relayer/src/server/kaspa/recover_deposit.rs
@@ -1,0 +1,117 @@
+use axum::{extract::State, http::StatusCode, Json};
+use dymension_kaspa::dym_kas_core::api::client::Deposit;
+use serde::{Deserialize, Serialize};
+
+use hyperlane_base::server::utils::{
+    ServerErrorBody, ServerErrorResponse, ServerResult, ServerSuccessResponse,
+};
+
+use super::ServerState;
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct RequestBody {
+    /// The Kaspa transaction ID to recover
+    pub kaspa_tx: String,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub struct ResponseBody {
+    pub message: String,
+    pub deposit_id: String,
+}
+
+/// Recover a Kaspa deposit by fetching it from the Kaspa REST API and submitting
+/// it for processing. This is useful for deposits that fell outside the normal
+/// lookback window due to relayer DB being wiped or other issues.
+///
+/// POST /kaspa/deposit/recover
+/// Body: { "kaspa_tx": "242b5987..." }
+pub async fn handler(
+    State(state): State<ServerState>,
+    Json(body): Json<RequestBody>,
+) -> ServerResult<ServerSuccessResponse<ResponseBody>> {
+    let RequestBody { kaspa_tx } = body;
+    tracing::info!(%kaspa_tx, "Received deposit recovery request");
+
+    // Check if recovery is enabled
+    let recovery = state.recovery.as_ref().ok_or_else(|| {
+        ServerErrorResponse::new(
+            StatusCode::SERVICE_UNAVAILABLE,
+            ServerErrorBody {
+                message: "Deposit recovery is not enabled on this relayer".to_string(),
+            },
+        )
+    })?;
+
+    // Fetch the transaction from Kaspa REST API
+    let tx = recovery
+        .http_client
+        .get_tx_by_id(&kaspa_tx)
+        .await
+        .map_err(|e| {
+            tracing::error!(%kaspa_tx, error = ?e, "Failed to fetch transaction from Kaspa API");
+            ServerErrorResponse::new(
+                StatusCode::NOT_FOUND,
+                ServerErrorBody {
+                    message: format!("Transaction not found or API error: {}", e),
+                },
+            )
+        })?;
+
+    // Validate it's a valid escrow transfer
+    if !is_valid_escrow_transfer(&tx, &recovery.escrow_address) {
+        return Err(ServerErrorResponse::new(
+            StatusCode::BAD_REQUEST,
+            ServerErrorBody {
+                message: format!(
+                    "Transaction {} is not a valid deposit to escrow {}",
+                    kaspa_tx, recovery.escrow_address
+                ),
+            },
+        ));
+    }
+
+    // Convert to Deposit
+    let deposit: Deposit = tx.try_into().map_err(|e: eyre::Error| {
+        tracing::error!(%kaspa_tx, error = ?e, "Failed to convert transaction to deposit");
+        ServerErrorResponse::new(
+            StatusCode::BAD_REQUEST,
+            ServerErrorBody {
+                message: format!("Invalid deposit transaction: {}", e),
+            },
+        )
+    })?;
+
+    let deposit_id = deposit.id.to_string();
+
+    // Send to recovery channel
+    recovery.sender.send(deposit).await.map_err(|e| {
+        tracing::error!(%kaspa_tx, error = ?e, "Failed to send deposit to recovery channel");
+        ServerErrorResponse::new(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            ServerErrorBody {
+                message: "Failed to queue deposit for recovery".to_string(),
+            },
+        )
+    })?;
+
+    tracing::info!(%kaspa_tx, %deposit_id, "Deposit queued for recovery");
+
+    Ok(ServerSuccessResponse::new(ResponseBody {
+        message: "Deposit queued for recovery processing".to_string(),
+        deposit_id,
+    }))
+}
+
+fn is_valid_escrow_transfer(
+    tx: &dymension_kaspa::dym_kas_api::models::TxModel,
+    escrow_address: &str,
+) -> bool {
+    tx.outputs.as_ref().map_or(false, |outputs| {
+        outputs.iter().any(|utxo| {
+            utxo.script_public_key_address
+                .as_ref()
+                .map_or(false, |dest| dest == escrow_address)
+        })
+    })
+}

--- a/rust/main/chains/dymension-kaspa/src/lib.rs
+++ b/rust/main/chains/dymension-kaspa/src/lib.rs
@@ -26,6 +26,7 @@ pub mod validator;
 
 // Direct reexports of lib stuff:
 pub use consts as hl_domains;
+pub use dym_kas_api;
 pub use dym_kas_core;
 pub use kaspa_addresses::Address as KaspaAddress;
 

--- a/rust/main/chains/dymension-kaspa/src/providers/provider.rs
+++ b/rust/main/chains/dymension-kaspa/src/providers/provider.rs
@@ -314,6 +314,10 @@ impl KaspaProvider {
             .expect("Kaspa key source not configured")
     }
 
+    pub fn try_kas_key_source(&self) -> Option<&crate::conf::KaspaEscrowKeySource> {
+        self.kas_key_source.as_ref()
+    }
+
     pub fn rest(&self) -> &RestProvider {
         &self.rest
     }

--- a/rust/main/hyperlane-base/src/kas_hack/mod.rs
+++ b/rust/main/hyperlane-base/src/kas_hack/mod.rs
@@ -6,5 +6,6 @@ pub mod migration;
 pub mod sync;
 
 pub use kaspa_db::KaspaRocksDB;
+pub use logic_loop::DepositRecoverySender;
 pub use migration::run_migration_with_sync;
 pub use sync::{ensure_hub_synced, format_ad_hoc_signatures};

--- a/rust/main/utils/kaspa-tools/Cargo.toml
+++ b/rust/main/utils/kaspa-tools/Cargo.toml
@@ -21,6 +21,7 @@ kaspa-wallet-core = { workspace = true }
 kaspa-wallet-keys = { workspace = true }
 kaspa-consensus-core = { workspace = true }
 kaspa-addresses = { workspace = true }
+kaspa-hashes = { workspace = true }
 workflow-core = { workspace = true }
 uuid = { version = "1.11", features = ["v4"] }
 hyperlane-core = { path = "../../hyperlane-core", features = ["ethers"] }

--- a/rust/main/utils/kaspa-tools/src/main.rs
+++ b/rust/main/utils/kaspa-tools/src/main.rs
@@ -76,6 +76,16 @@ async fn run(cli: Cli) {
                 std::process::exit(1);
             }
         }
+        Commands::ComputeDepositId(args) => {
+            if let Err(e) = x::compute_deposit_id::compute_deposit_id(
+                &args.payload,
+                &args.tx_id,
+                args.utxo_index,
+            ) {
+                eprintln!("compute deposit id: {e}");
+                std::process::exit(1);
+            }
+        }
     }
 }
 

--- a/rust/main/utils/kaspa-tools/src/x/args.rs
+++ b/rust/main/utils/kaspa-tools/src/x/args.rs
@@ -43,6 +43,9 @@ pub enum Commands {
     /// Decode a Kaspa withdrawal tx payload to extract Hyperlane message IDs
     #[clap(name = "decode-payload")]
     DecodePayload(DecodePayloadCli),
+    /// Compute the Hyperlane message ID for a Kaspa deposit transaction
+    #[clap(name = "compute-deposit-id")]
+    ComputeDepositId(ComputeDepositIdCli),
 }
 
 #[derive(Subcommand, Debug)]
@@ -310,4 +313,18 @@ pub struct DecodePayloadCli {
     /// This is the payload field from a Kaspa withdrawal transaction.
     #[arg(required = true, index = 1)]
     pub payload: String,
+}
+
+#[derive(Args, Debug)]
+pub struct ComputeDepositIdCli {
+    /// The deposit payload (hex string, with or without 0x prefix).
+    /// This is the HyperlaneMessage payload from a Kaspa deposit transaction.
+    #[arg(required = true, index = 1)]
+    pub payload: String,
+    /// The Kaspa transaction ID (hex string, with or without 0x prefix).
+    #[arg(required = true, index = 2)]
+    pub tx_id: String,
+    /// The UTXO index of the deposit output in the transaction.
+    #[arg(required = true, index = 3)]
+    pub utxo_index: usize,
 }

--- a/rust/main/utils/kaspa-tools/src/x/compute_deposit_id.rs
+++ b/rust/main/utils/kaspa-tools/src/x/compute_deposit_id.rs
@@ -1,0 +1,80 @@
+use dymension_kaspa::ops::message::{add_kaspa_metadata_hl_messsage, ParsedHL};
+use eyre::Result;
+use kaspa_hashes::Hash;
+
+use std::str::FromStr as _;
+
+/// Compute the Hyperlane message ID for a Kaspa deposit.
+///
+/// The message ID is deterministically derived from the deposit payload combined
+/// with the Kaspa transaction metadata (tx_id, utxo_index). This allows verifying
+/// whether a deposit has been processed on the Dymension hub.
+pub fn compute_deposit_id(payload: &str, tx_id: &str, utxo_index: usize) -> Result<()> {
+    let payload = payload.strip_prefix("0x").unwrap_or(payload);
+    let tx_id = tx_id.strip_prefix("0x").unwrap_or(tx_id);
+
+    let parsed = ParsedHL::parse_string(payload)?;
+
+    let tx_hash =
+        Hash::from_str(tx_id).map_err(|e| eyre::eyre!("invalid transaction ID: {}", e))?;
+
+    let hl_message_with_metadata = add_kaspa_metadata_hl_messsage(parsed, tx_hash, utxo_index)?;
+
+    let message_id = hl_message_with_metadata.id();
+
+    println!(
+        "Hyperlane Message ID: 0x{}",
+        hex::encode(message_id.as_bytes())
+    );
+    println!();
+    println!("To check delivery on Dymension hub:");
+    println!(
+        "  dymd q hyperlane delivered <mailbox_id> 0x{}",
+        hex::encode(message_id.as_bytes())
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_compute_deposit_id_basic() {
+        // This payload is from the user's real transaction
+        let payload = "03000000014088489d00000000000000000000000000000000000000000000000000000000000000005d990b31726f757465725f617070000000000000000000000000000200000000000000000000000000000000000000005b1ae7408e939e381f1d39b8d5dbe9aae7653453000000000000000000000000000000000000000000000000000000174876e800";
+        let tx_id = "242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79";
+        let utxo_index = 0;
+
+        let result = compute_deposit_id(payload, tx_id, utxo_index);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compute_deposit_id_with_0x_prefix() {
+        let payload = "0x03000000014088489d00000000000000000000000000000000000000000000000000000000000000005d990b31726f757465725f617070000000000000000000000000000200000000000000000000000000000000000000005b1ae7408e939e381f1d39b8d5dbe9aae7653453000000000000000000000000000000000000000000000000000000174876e800";
+        let tx_id = "0x242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79";
+        let utxo_index = 0;
+
+        let result = compute_deposit_id(payload, tx_id, utxo_index);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_compute_deposit_id_invalid_payload() {
+        let result = compute_deposit_id(
+            "invalid_hex",
+            "242b5987b89e939a8777d42072bbd3527dcfceb61048a4cf874fc473f76a1b79",
+            0,
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compute_deposit_id_invalid_tx_id() {
+        let payload = "03000000014088489d00000000000000000000000000000000000000000000000000000000000000005d990b31726f757465725f617070000000000000000000000000000200000000000000000000000000000000000000005b1ae7408e939e381f1d39b8d5dbe9aae7653453000000000000000000000000000000000000000000000000000000174876e800";
+        let result = compute_deposit_id(payload, "invalid_tx_id", 0);
+        assert!(result.is_err());
+    }
+}

--- a/rust/main/utils/kaspa-tools/src/x/mod.rs
+++ b/rust/main/utils/kaspa-tools/src/x/mod.rs
@@ -1,4 +1,5 @@
 pub mod args;
+pub mod compute_deposit_id;
 pub mod decode_payload;
 pub mod deposit;
 pub mod escrow;


### PR DESCRIPTION
## Summary

- Add POST `/kaspa/deposit/recover` endpoint to manually recover Kaspa deposits that fell outside the normal lookback window
- Useful when relayer DB has been wiped or for deposits that were missed for other reasons
- Fetches transaction from Kaspa REST API, validates it's an escrow transfer, and queues it for processing

## Usage

```bash
curl -X POST https://kaspa-relayer.mzonder.com/kaspa/deposit/recover \
  -H "Content-Type: application/json" \
  -d '{"kaspa_tx": "242b5987..."}'
```

## Test plan

- [ ] Deploy to staging/testnet relayer
- [ ] Test with a known historical deposit that was missed
- [ ] Verify the deposit gets processed through the normal pipeline
- [ ] Verify error handling for invalid/non-escrow transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)